### PR TITLE
[Feat] 배송지 추가 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -1,19 +1,36 @@
-//package com.sparta.project.controller;
-//
-//import com.sparta.project.dto.address.AddressRequest;
-//import com.sparta.project.dto.address.AddressResponse;
-//import com.sparta.project.dto.common.ApiResponse;
-//import com.sparta.project.dto.common.PageResponse;
-//import com.sparta.project.service.AddressService;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.web.bind.annotation.*;
-//
-//import java.util.List;
-//
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/addresses")
-//public class AddressController {
+package com.sparta.project.controller;
+
+
+import com.sparta.project.domain.Address;
+import com.sparta.project.dto.address.AddressCreateRequest;
+import com.sparta.project.dto.common.ApiResponse;
+import com.sparta.project.service.AddressService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/addresses")
+public class AddressController {
+
+    private final AddressService addressService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public ApiResponse<Void> createAddress(Authentication authentication,
+                                              @Valid @RequestBody AddressCreateRequest request) {
+        addressService.createAddress(Long.parseLong(authentication.getName()), request);
+        return ApiResponse.success();
+    }
+
+
 //
 //    private final AddressService addressService;
 //
@@ -56,4 +73,4 @@
 //        addressService.deleteAddress(address_id);
 //        return ApiResponse.success();
 //    }
-//}
+}

--- a/src/main/java/com/sparta/project/domain/Address.java
+++ b/src/main/java/com/sparta/project/domain/Address.java
@@ -37,6 +37,10 @@ public class Address extends BaseEntity { // 배송지
 	@Column(name="is_default") // 메인 주소지 여부
 	private Boolean isDefault;
 
+	public void updateDefault(Boolean isDefault) {
+		this.isDefault = isDefault;
+	}
+
 	@Builder
 	private Address(User user, String city, String district, String streetName, String streetNumber, String detail, Boolean isDefault) {
 		this.user = user;

--- a/src/main/java/com/sparta/project/domain/Address.java
+++ b/src/main/java/com/sparta/project/domain/Address.java
@@ -1,9 +1,8 @@
 package com.sparta.project.domain;
 
+
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -12,6 +11,7 @@ import org.hibernate.annotations.OnDeleteAction;
 @Table(name="p_address")
 public class Address extends BaseEntity { // 배송지
 	@Id
+	@GeneratedValue(strategy=GenerationType.UUID)
 	@Column(name="address_id", length=36, nullable=false, updatable=false)
 	private String addressId;
 

--- a/src/main/java/com/sparta/project/domain/Address.java
+++ b/src/main/java/com/sparta/project/domain/Address.java
@@ -38,8 +38,7 @@ public class Address extends BaseEntity { // 배송지
 	private Boolean isDefault;
 
 	@Builder
-	public Address(String addressId, User user, String city, String district, String streetName, String streetNumber, String detail, Boolean isDefault) {
-		this.addressId = addressId;
+	private Address(User user, String city, String district, String streetName, String streetNumber, String detail, Boolean isDefault) {
 		this.user = user;
 		this.city = city;
 		this.district = district;
@@ -47,6 +46,18 @@ public class Address extends BaseEntity { // 배송지
 		this.streetNumber = streetNumber;
 		this.detail = detail;
 		this.isDefault = isDefault;
+	}
+
+	public static Address create(User user, String city, String district, String streetName, String streetNumber, String detail, Boolean isDefault) {
+		return Address.builder()
+				.user(user)
+				.city(city)
+				.district(district)
+				.streetName(streetName)
+				.streetNumber(streetNumber)
+				.detail(detail)
+				.isDefault(isDefault)
+				.build();
 	}
 
 }

--- a/src/main/java/com/sparta/project/dto/address/AddressCreateRequest.java
+++ b/src/main/java/com/sparta/project/dto/address/AddressCreateRequest.java
@@ -1,0 +1,14 @@
+package com.sparta.project.dto.address;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AddressCreateRequest(
+        @NotBlank String city,
+        @NotBlank String district,
+        @NotBlank String streetName,
+        @NotBlank String streetNumber,
+        @NotBlank String detail,
+        @NotNull Boolean isDefault
+) {
+}

--- a/src/main/java/com/sparta/project/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/project/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 존재하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호 정보가 일치하지 않습니다."),
 
+    // Address
+    EXCEED_MAXIMUM_ADDRESS(HttpStatus.CONFLICT, "등록할 수 있는 최대 배송지 수를 초과했습니다."),
+
     // Location
     LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 지역 정보가 존재하지 않습니다."),
 
@@ -22,7 +25,7 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 카테고리 정보가 존재하지 않습니다."),
 
     // NOT FOUND
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 유저 정보가 존재하지 않습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 유저 정보가 존재하지 않습니다."),
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 메뉴 정보가 존재하지 않습니다."),
     AIDESCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 AI설명 정보가 존재하지 않습니다."),
 

--- a/src/main/java/com/sparta/project/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/project/repository/AddressRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, String> {
-
-
+    Address findByUserAndIsDefault(User user, boolean isDefault);
+    boolean existsByUserAndIsDefault(User user, boolean isDefault);
 }

--- a/src/main/java/com/sparta/project/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/project/repository/AddressRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.project.repository;
+
+
+import com.sparta.project.domain.Address;
+import com.sparta.project.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AddressRepository extends JpaRepository<Address, String> {
+
+
+}

--- a/src/main/java/com/sparta/project/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/project/repository/AddressRepository.java
@@ -10,4 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface AddressRepository extends JpaRepository<Address, String> {
     Address findByUserAndIsDefault(User user, boolean isDefault);
     boolean existsByUserAndIsDefault(User user, boolean isDefault);
+    int countByUser(User user);
 }

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -1,0 +1,35 @@
+package com.sparta.project.service;
+
+
+import com.sparta.project.domain.Address;
+import com.sparta.project.domain.User;
+import com.sparta.project.domain.enums.Role;
+import com.sparta.project.dto.address.AddressCreateRequest;
+import com.sparta.project.exception.CodeBloomException;
+import com.sparta.project.exception.ErrorCode;
+import com.sparta.project.repository.AddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AddressService {
+
+    private final UserService userService;
+    private final AddressRepository addressRepository;
+
+
+    @Transactional
+    public void createAddress(final long userId, final AddressCreateRequest request) {
+        User user = userService.getUserOrException(userId);
+        if(user.getRole() != Role.CUSTOMER) {
+            throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        addressRepository.save(Address.create(
+                user, request.city(), request.district(), request.streetName(),
+                request.streetNumber(), request.detail(), request.isDefault()
+        ));
+    }
+
+}

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -26,10 +26,20 @@ public class AddressService {
         if(user.getRole() != Role.CUSTOMER) {
             throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
         }
+
+        if(request.isDefault() && alreadyExistDefault(user)) {
+            Address defaultAddress = addressRepository.findByUserAndIsDefault(user, true);
+            defaultAddress.updateDefault(false);
+        }
+
         addressRepository.save(Address.create(
                 user, request.city(), request.district(), request.streetName(),
                 request.streetNumber(), request.detail(), request.isDefault()
         ));
+    }
+
+    private boolean alreadyExistDefault(final User user) {
+        return addressRepository.existsByUserAndIsDefault(user, true);
     }
 
 }

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -26,16 +26,21 @@ public class AddressService {
         if(user.getRole() != Role.CUSTOMER) {
             throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
         }
-
+        if(overMaxAddress(user)) {
+            throw new CodeBloomException(ErrorCode.EXCEED_MAXIMUM_ADDRESS);
+        }
         if(request.isDefault() && alreadyExistDefault(user)) {
             Address defaultAddress = addressRepository.findByUserAndIsDefault(user, true);
             defaultAddress.updateDefault(false);
         }
-
         addressRepository.save(Address.create(
                 user, request.city(), request.district(), request.streetName(),
                 request.streetNumber(), request.detail(), request.isDefault()
         ));
+    }
+
+    private boolean overMaxAddress(final User user) {
+        return addressRepository.countByUser(user) > 5;
     }
 
     private boolean alreadyExistDefault(final User user) {


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #26 

배송지를 추가하는 API를 개발하였습니다.
- 요청한 유저의 권한이 CUSTOMER가 아닌 경우 오류가 반환됩니다.
- 기존 유저가 가진 배송지가 5개 이상인 경우 오류가 반환됩니다.
- 기본 배송지가 있는 경우에 기본 배송지로 생성 요청을 받을 경우 이전의 기본 배송지는 false로 바뀌게 됩니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 배송지 엔티티 생성 방식을 `@GeneratedValue(strategy=GenerationType.UUID)` 로 설정

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->



**성공시**

보낸 데이터
```Java
{
    "city" : "경기도",
    "district" : "의정부시",
    "streetName" : "발곡로",
    "streetNumber" : "221",
    "detail" : "504동 501호",
    "isDefault" : true
}
```
응답
![image](https://github.com/user-attachments/assets/169bfc3a-5ed4-4b1e-99d2-8c368f18c731)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 현재 한 사람이 가질 수 있는 배송지 수를 5개로 제한하였는데 괜찮은가요?
- 그 외 질문하실 점, 개선 방안 등 편하게 의견 주세요! 😃

