### PR TITLE
[Feat] 가게 카테고리 생성 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/project/controller/StoreCategoryController.java
@@ -19,6 +19,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/categories")
 public class StoreCategoryController {
+
+    private final StoreCategoryService storeCategoryService;
+
+
+    @PostMapping
+    public ApiResponse<Void> createStoreCategory(Authentication authentication,
+                                                 @Valid @RequestBody StoreCategoryCreateRequest request) {
+        checkStoreCategoryAuth(authentication.getAuthorities());
+        storeCategoryService.createStoreCategory(request);
+        return ApiResponse.success();
+    }
+
     private void checkStoreCategoryAuth(Collection<? extends GrantedAuthority> authorities) {
         String role = authorities.toArray()[0].toString();
         if(!role.equals("MANAGER") && !role.equals("MASTER")) {

--- a/src/main/java/com/sparta/project/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/project/controller/StoreCategoryController.java
@@ -1,17 +1,31 @@
-//package com.sparta.project.controller;
-//
-//import com.sparta.project.dto.storeCategory.StoreCategoryRequest;
-//import com.sparta.project.dto.storeCategory.StoreCategoryResponse;
-//import com.sparta.project.dto.common.ApiResponse;
-//import com.sparta.project.dto.common.PageResponse;
-//import com.sparta.project.service.StoreCategoryService;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.web.bind.annotation.*;
-//
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/categories")
-//public class StoreCategoryController {
+package com.sparta.project.controller;
+
+import com.sparta.project.dto.common.ApiResponse;
+import com.sparta.project.dto.storecategory.StoreCategoryCreateRequest;
+import com.sparta.project.exception.CodeBloomException;
+import com.sparta.project.exception.ErrorCode;
+import com.sparta.project.service.StoreCategoryService;
+import jakarta.validation.Valid;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/categories")
+public class StoreCategoryController {
+    private void checkStoreCategoryAuth(Collection<? extends GrantedAuthority> authorities) {
+        String role = authorities.toArray()[0].toString();
+        if(!role.equals("MANAGER") && !role.equals("MASTER")) {
+            throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
+
 //
 //    private final StoreCategoryService storeCategoryService;
 //
@@ -55,4 +69,4 @@
 //        storeCategoryService.deleteStoreCategory(category_id);
 //        return ApiResponse.success();
 //    }
-//}
+}

--- a/src/main/java/com/sparta/project/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/project/controller/StoreCategoryController.java
@@ -2,14 +2,11 @@ package com.sparta.project.controller;
 
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.storecategory.StoreCategoryCreateRequest;
-import com.sparta.project.exception.CodeBloomException;
-import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.service.StoreCategoryService;
+import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
-import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,22 +17,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/categories")
 public class StoreCategoryController {
 
+    private final PermissionValidator permissionValidator;
     private final StoreCategoryService storeCategoryService;
 
 
     @PostMapping
     public ApiResponse<Void> createStoreCategory(Authentication authentication,
                                                  @Valid @RequestBody StoreCategoryCreateRequest request) {
-        checkStoreCategoryAuth(authentication.getAuthorities());
+        permissionValidator.checkPermission(authentication, "MANAGER", "MASTER");
         storeCategoryService.createStoreCategory(request);
         return ApiResponse.success();
-    }
-
-    private void checkStoreCategoryAuth(Collection<? extends GrantedAuthority> authorities) {
-        String role = authorities.toArray()[0].toString();
-        if(!role.equals("MANAGER") && !role.equals("MASTER")) {
-            throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
-        }
     }
 
 //

--- a/src/main/java/com/sparta/project/domain/StoreCategory.java
+++ b/src/main/java/com/sparta/project/domain/StoreCategory.java
@@ -2,6 +2,8 @@ package com.sparta.project.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.*;
@@ -14,6 +16,7 @@ import lombok.*;
 public class StoreCategory extends BaseEntity { // 음식점 카테고리
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name="store_category_id", length=36, nullable=false, updatable=false)
     private String storeCategoryId;
 

--- a/src/main/java/com/sparta/project/domain/StoreCategory.java
+++ b/src/main/java/com/sparta/project/domain/StoreCategory.java
@@ -27,10 +27,17 @@ public class StoreCategory extends BaseEntity { // 음식점 카테고리
     private String description;
 
     @Builder
-    public StoreCategory(String storeCategoryId, String name, String description) {
+    private StoreCategory(String storeCategoryId, String name, String description) {
         this.storeCategoryId = storeCategoryId;
         this.name = name;
         this.description = description;
+    }
+
+    public static StoreCategory create(String name, String description) {
+        return StoreCategory.builder()
+                .name(name)
+                .description(description)
+                .build();
     }
 
 }

--- a/src/main/java/com/sparta/project/dto/storecategory/StoreCategoryCreateRequest.java
+++ b/src/main/java/com/sparta/project/dto/storecategory/StoreCategoryCreateRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.project.dto.storecategory;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StoreCategoryCreateRequest(
+        @NotBlank String name,
+        @NotBlank String description
+) {
+}

--- a/src/main/java/com/sparta/project/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/project/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 
     // Store-category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 카테고리 정보가 존재하지 않습니다."),
+    CATEGORY_ALREADY_EXIST(HttpStatus.CONFLICT, "카테고리가 이미 존재합니다."),
 
     // NOT FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 유저 정보가 존재하지 않습니다."),

--- a/src/main/java/com/sparta/project/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/project/repository/StoreCategoryRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, String> {
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/sparta/project/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/project/service/StoreCategoryService.java
@@ -29,4 +29,11 @@ public class StoreCategoryService {
                 .build()
         );
     }
+
+    private void checkNameDuplication(String newName) {
+        if(storeCategoryRepository.existsByName(newName)) {
+            throw new CodeBloomException(ErrorCode.CATEGORY_ALREADY_EXIST);
+        }
+    }
+
 }

--- a/src/main/java/com/sparta/project/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/project/service/StoreCategoryService.java
@@ -1,15 +1,18 @@
 package com.sparta.project.service;
 
 import com.sparta.project.domain.StoreCategory;
+import com.sparta.project.dto.storecategory.StoreCategoryCreateRequest;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.repository.StoreCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class StoreCategoryService {
+
     private final StoreCategoryRepository storeCategoryRepository;
 
     public StoreCategory getStoreCategoryOrException(String categoryId) {
@@ -17,4 +20,13 @@ public class StoreCategoryService {
                 new CodeBloomException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 
+    @Transactional
+    public void createStoreCategory(final StoreCategoryCreateRequest request) {
+        checkNameDuplication(request.name());
+        storeCategoryRepository.save(StoreCategory.builder()
+                .name(request.name())
+                .description(request.description())
+                .build()
+        );
+    }
 }

--- a/src/main/java/com/sparta/project/util/PermissionValidator.java
+++ b/src/main/java/com/sparta/project/util/PermissionValidator.java
@@ -1,0 +1,23 @@
+package com.sparta.project.util;
+
+
+import com.sparta.project.exception.CodeBloomException;
+import com.sparta.project.exception.ErrorCode;
+import java.util.Arrays;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PermissionValidator {
+
+    public void checkPermission(Authentication authentication, String... roles) {
+        boolean hasPermission = Arrays.stream(roles)
+                .anyMatch(role -> authentication.getAuthorities()
+                                .contains(new SimpleGrantedAuthority(role)));
+        if (!hasPermission) {
+            throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #30 

가게 카테고리를 생성하는 API 를 개발했습니다.
- 로그인한 유저의 권한이 MANAGER, MASTER 가 아닌 경우 오류 반환
- 생성 요청으로 받은 카테고리 명이 이미 존재하는 경우 오류 반환
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- ErrorCode: 중복되는 카테고리가 있는 경우의 에러 코드 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공
![image](https://github.com/user-attachments/assets/1acd9c7d-87f4-4323-9615-16f99dcca3f1)

- 권한이 없는 경우
![image](https://github.com/user-attachments/assets/917356e4-8445-4b37-923c-2ec4c18340d5)

- name 을 똑같이 보냈을 경우
![image](https://github.com/user-attachments/assets/3d94480c-6367-4507-9965-a95508dac877)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 중복되는 카테고리가 있는 경우의 오류 메세지가 잘 떠오르지 않아서 일단 저렇게 작성했는데 혹시 다른 좋은 아이디어 있으시면 제안해주시면 감사하겠습니다!! ex 같은 이름의 카테고리가 이미 존재합니다
- 그 외 궁금하신 점, 개선 방안 등 의견 편하게 주세요! 😃