### PR TITLE
[Feat] 가게 요청 승인 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreRequestController.java
+++ b/src/main/java/com/sparta/project/controller/StoreRequestController.java
@@ -21,7 +21,6 @@ public class StoreRequestController {
 
     private final StoreRequestService storeRequestService;
 
-    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public ApiResponse<Void> createStoreRequest(Authentication authentication,
                                                 @Valid @RequestBody StoreCreateRequest request) {

--- a/src/main/java/com/sparta/project/controller/StoreRequestController.java
+++ b/src/main/java/com/sparta/project/controller/StoreRequestController.java
@@ -1,12 +1,15 @@
 package com.sparta.project.controller;
 
+import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.storerequest.StoreCreateRequest;
 import com.sparta.project.service.StoreRequestService;
+import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/store-requests")
 public class StoreRequestController {
 
+    private final PermissionValidator permissionValidator;
     private final StoreRequestService storeRequestService;
 
     @PostMapping
@@ -27,6 +31,22 @@ public class StoreRequestController {
         storeRequestService.createStoreRequest(Long.parseLong(authentication.getName()), request);
         return ApiResponse.success();
     }
+
+    @PostMapping("/{request_id}")
+    public ApiResponse<Void> updateStoreRequest(Authentication authentication,
+                                                @PathVariable String request_id) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        storeRequestService.approveStoreRequest(request_id);
+        return ApiResponse.success();
+    }
+
+//
+//    // 음식점 생성 요청 반려(MANAGER, MASTER)
+//    @DeleteMapping("/{request_id}")
+//    public ApiResponse<Void> deleteStoreRequest(@PathVariable String request_id) {
+//        storeRequestService.deleteStoreRequest(request_id);
+//        return ApiResponse.success();
+//    }
 
 //
 //    // 자신의 요청 목록 조회(OWNER)
@@ -70,19 +90,5 @@ public class StoreRequestController {
 //    }
 //
 //
-//    // 음식점 생성 요청 승인(MANAGER, MASTER)
-//    @PostMapping("/{request_id}")
-//    public ApiResponse<StoreRequestResponse> updateStoreRequest(
-//            @PathVariable String request_id,
-//            @RequestBody StoreRequestRequest storeRequestRequest) {
-//        StoreRequestResponse approvedRequest = storeRequestService.updateStoreRequest(request_id, storeRequestRequest);
-//        return ApiResponse.success(approvedRequest);
-//    }
-//
-//    // 음식점 생성 요청 반려(MANAGER, MASTER)
-//    @DeleteMapping("/{request_id}")
-//    public ApiResponse<Void> deleteStoreRequest(@PathVariable String request_id) {
-//        storeRequestService.deleteStoreRequest(request_id);
-//        return ApiResponse.success();
-//    }
+
 }

--- a/src/main/java/com/sparta/project/domain/Store.java
+++ b/src/main/java/com/sparta/project/domain/Store.java
@@ -12,6 +12,7 @@ import org.hibernate.annotations.OnDeleteAction;
 @Table(name="p_store")
 public class Store extends BaseEntity { // 음식점
 	@Id
+	@GeneratedValue(strategy=GenerationType.UUID)
 	@Column(name="store_id", length=36, nullable=false, updatable=false)
 	private String storeId;
 

--- a/src/main/java/com/sparta/project/domain/Store.java
+++ b/src/main/java/com/sparta/project/domain/Store.java
@@ -2,8 +2,6 @@ package com.sparta.project.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,9 +38,9 @@ public class Store extends BaseEntity { // 음식점
 	@Column(name="score") // 음식점 리뷰 평균 평점
 	private Double score; // 빌더에 넣지 않았습니다.
 
+
 	@Builder
-	public Store(String storeId, String name, String description, String address, User owner, StoreCategory storeCategory, Location location) {
-		this.storeId = storeId;
+	private Store(String name, String description, String address, User owner, StoreCategory storeCategory, Location location) {
 		this.name = name;
 		this.description = description;
 		this.address = address;
@@ -51,8 +49,15 @@ public class Store extends BaseEntity { // 음식점
 		this.location = location;
 	}
 
-	public void updateScore(Double score) {
-		this.score = score;
+	public static Store create(String name, String description, String address, User owner, StoreCategory storeCategory, Location location) {
+		return Store.builder()
+				.name(name)
+				.description(description)
+				.address(address)
+				.owner(owner)
+				.storeCategory(storeCategory)
+				.location(location)
+				.build();
 	}
 
 }

--- a/src/main/java/com/sparta/project/domain/StoreRequest.java
+++ b/src/main/java/com/sparta/project/domain/StoreRequest.java
@@ -15,6 +15,7 @@ import org.hibernate.annotations.OnDeleteAction;
 @Table(name="p_store_request")
 public class StoreRequest extends BaseEntity { // 음식점 허가 요청
 	@Id
+	@GeneratedValue(strategy=GenerationType.UUID)
 	@Column(name="store_request_id", length=36, nullable=false, updatable=false)
 	private String storeRequestId;
 

--- a/src/main/java/com/sparta/project/domain/StoreRequest.java
+++ b/src/main/java/com/sparta/project/domain/StoreRequest.java
@@ -50,6 +50,10 @@ public class StoreRequest extends BaseEntity { // 음식점 허가 요청
 		this.status = StoreRequestStatus.WAITING;
 	}
 
+	public void updateStatus(StoreRequestStatus status) {
+		this.status = status;
+	}
+
 	@Builder
 	private StoreRequest(String id, String name, String description, String address, User owner, StoreCategory category, Location location) {
 		this.storeRequestId = id;

--- a/src/main/java/com/sparta/project/dto/store/StoreCreateData.java
+++ b/src/main/java/com/sparta/project/dto/store/StoreCreateData.java
@@ -1,0 +1,26 @@
+package com.sparta.project.dto.store;
+
+import com.sparta.project.domain.Location;
+import com.sparta.project.domain.StoreCategory;
+import com.sparta.project.domain.StoreRequest;
+import com.sparta.project.domain.User;
+
+public record StoreCreateData(
+        String name,
+        String description,
+        String address,
+        User owner,
+        StoreCategory storeCategory,
+        Location location
+) {
+    public static StoreCreateData from(StoreRequest request) {
+        return new StoreCreateData(
+                request.getName(),
+                request.getDescription(),
+                request.getAddress(),
+                request.getOwner(),
+                request.getStoreCategory(),
+                request.getLocation()
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/project/exception/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
     // API CALL FAILED
     API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "API 호출이 실패했습니다."),
 
+    // Util
+    ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),
+
     // UNAUTHORIZED & FORBIDDEN
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 존재하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호 정보가 일치하지 않습니다."),

--- a/src/main/java/com/sparta/project/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/project/exception/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
     // Location
     LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 지역 정보가 존재하지 않습니다."),
 
+    // Store-request
+    STORE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 가게 요청 정보가 존재하지 않습니다."),
+
     // Store-category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 카테고리 정보가 존재하지 않습니다."),
     CATEGORY_ALREADY_EXIST(HttpStatus.CONFLICT, "카테고리가 이미 존재합니다."),

--- a/src/main/java/com/sparta/project/service/StoreRequestService.java
+++ b/src/main/java/com/sparta/project/service/StoreRequestService.java
@@ -41,6 +41,7 @@ public class StoreRequestService {
     public void approveStoreRequest(String storeRequestId) {
         StoreRequest storeRequest = getStoreRequestOrException(storeRequestId);
         checkAlreadyChanged(storeRequest.getStatus(), StoreRequestStatus.APPROVE);
+        storeRequest.updateStatus(StoreRequestStatus.APPROVE);
         storeService.createStore(StoreCreateData.from(storeRequest));
     }
 

--- a/src/main/java/com/sparta/project/service/StoreRequestService.java
+++ b/src/main/java/com/sparta/project/service/StoreRequestService.java
@@ -40,9 +40,15 @@ public class StoreRequestService {
     @Transactional
     public void approveStoreRequest(String storeRequestId) {
         StoreRequest storeRequest = getStoreRequestOrException(storeRequestId);
+        checkAlreadyChanged(storeRequest.getStatus(), StoreRequestStatus.APPROVE);
         storeService.createStore(StoreCreateData.from(storeRequest));
     }
 
+    private void checkAlreadyChanged(StoreRequestStatus before, StoreRequestStatus change) {
+        if(before==change) {
+            throw new CodeBloomException(ErrorCode.ALREADY_PROCESSED);
+        }
+    }
 
     private StoreRequest getStoreRequestOrException(String id) {
         return storeRequestRepository.findById(id).orElseThrow(()->

--- a/src/main/java/com/sparta/project/service/StoreRequestService.java
+++ b/src/main/java/com/sparta/project/service/StoreRequestService.java
@@ -4,6 +4,8 @@ package com.sparta.project.service;
 import com.sparta.project.domain.StoreRequest;
 import com.sparta.project.domain.User;
 import com.sparta.project.domain.enums.Role;
+import com.sparta.project.domain.enums.StoreRequestStatus;
+import com.sparta.project.dto.store.StoreCreateData;
 import com.sparta.project.dto.storerequest.StoreCreateRequest;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class StoreRequestService {
 
     private final UserService userService;
+    private final StoreService storeService;
     private final StoreCategoryService categoryService;
     private final StoreLocationService locationService;
     private final StoreRequestRepository storeRequestRepository;
@@ -27,13 +30,23 @@ public class StoreRequestService {
         if(user.getRole()!= Role.OWNER) {
             throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
         }
-
         storeRequestRepository.save(StoreRequest.create(
                 request.name(), request.description(), request.address(), user,
                 categoryService.getStoreCategoryOrException(request.storeCategoryId()),
                 locationService.getStoreLocationOrException(request.locationId())
         ));
+    }
 
+    @Transactional
+    public void approveStoreRequest(String storeRequestId) {
+        StoreRequest storeRequest = getStoreRequestOrException(storeRequestId);
+        storeService.createStore(StoreCreateData.from(storeRequest));
+    }
+
+
+    private StoreRequest getStoreRequestOrException(String id) {
+        return storeRequestRepository.findById(id).orElseThrow(()->
+                new CodeBloomException(ErrorCode.STORE_REQUEST_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/sparta/project/service/StoreService.java
+++ b/src/main/java/com/sparta/project/service/StoreService.java
@@ -1,0 +1,22 @@
+package com.sparta.project.service;
+
+import com.sparta.project.domain.Store;
+import com.sparta.project.dto.store.StoreCreateData;
+import com.sparta.project.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+
+    public void createStore(final StoreCreateData data) {
+        storeRepository.save(Store.create(
+                data.name(), data.description(), data.address(),
+                data.owner(), data.storeCategory(), data.location()
+        ));
+    }
+
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #34 

가게 요청을 승인하는 API를 개발했습니다.
- 이미 승인 된 요청인 경우 오류 반환
- 사용자 권한이 MANAGER, MASTER가 아닌 경우 오류 반환

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- ErrorCode: 이미 처리된 요청, 일피하는 가게 요청 없는 경우의 오류 코드 추가
- 가게 생성을 위한 Dto 추가
- 가게 요청 엔티티에 상태 업데이트하는 메서드 추가
- 가게 요청, 가게 엔티티 아니디 자동으로 생성되도록 변경

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공
![image](https://github.com/user-attachments/assets/d3e728be-13d1-424c-9308-56dfa0280d3d)

- 권한이 MANAGER, MASTER 가 아닌 경우
![image](https://github.com/user-attachments/assets/308c69d4-e61a-4090-a4ea-9986e27b1537)

- 이미 승인을 완료한 경우
![image](https://github.com/user-attachments/assets/28f0c494-b26d-446c-8b0d-5e06171b687d)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- ALREADY_PROCESSED 에러 코드는 다른 곳에서도 사용될 수 있다고 생각해 주석을 util로 분류했습니다!
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃