### PR TITLE
[Feat] 배송지 수정 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -24,7 +24,7 @@ public class AddressController {
     private final PermissionValidator permissionValidator;
     private final AddressService addressService;
 
-    @ResponseStatus(HttpStatus.CREATED)
+
     @PostMapping
     public ApiResponse<Void> createAddress(Authentication authentication,
                                            @Valid @RequestBody AddressCreateRequest request) {

--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -5,6 +5,7 @@ import com.sparta.project.domain.Address;
 import com.sparta.project.dto.address.AddressCreateRequest;
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.service.AddressService;
+import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,12 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/addresses")
 public class AddressController {
 
+    private final PermissionValidator permissionValidator;
     private final AddressService addressService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public ApiResponse<Void> createAddress(Authentication authentication,
-                                              @Valid @RequestBody AddressCreateRequest request) {
+                                           @Valid @RequestBody AddressCreateRequest request) {
+        permissionValidator.checkPermission(authentication, Role.CUSTOMER.name());
         addressService.createAddress(Long.parseLong(authentication.getName()), request);
         return ApiResponse.success();
     }

--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -2,7 +2,9 @@ package com.sparta.project.controller;
 
 
 import com.sparta.project.domain.Address;
+import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.address.AddressCreateRequest;
+import com.sparta.project.dto.address.AddressUpdateRequest;
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.service.AddressService;
 import com.sparta.project.util.PermissionValidator;
@@ -10,6 +12,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +34,14 @@ public class AddressController {
                                            @Valid @RequestBody AddressCreateRequest request) {
         permissionValidator.checkPermission(authentication, Role.CUSTOMER.name());
         addressService.createAddress(Long.parseLong(authentication.getName()), request);
+        return ApiResponse.success();
+    }
+
+    @PatchMapping("/{address_id}")
+    public ApiResponse<Void> updateAddress(Authentication authentication,
+                                           @PathVariable String address_id,
+                                           @RequestBody AddressUpdateRequest request) {
+        addressService.updateAddress(Long.parseLong(authentication.getName()), address_id, request);
         return ApiResponse.success();
     }
 

--- a/src/main/java/com/sparta/project/domain/Address.java
+++ b/src/main/java/com/sparta/project/domain/Address.java
@@ -41,8 +41,19 @@ public class Address extends BaseEntity { // 배송지
 		this.isDefault = isDefault;
 	}
 
+	public void update(String city, String district, String streetName,
+					   String streetNumber, String detail, Boolean isDefault) {
+		if(city!=null) this.city = city;
+		if(district!=null) this.district = district;
+		if(streetName!=null) this.streetName = streetName;
+		if(streetNumber!=null) this.streetNumber = streetNumber;
+		if(detail!=null) this.detail = detail;
+		if(isDefault!=null) this.isDefault = isDefault;
+	}
+
 	@Builder
-	private Address(User user, String city, String district, String streetName, String streetNumber, String detail, Boolean isDefault) {
+	private Address(User user, String city, String district, String streetName,
+					String streetNumber, String detail, Boolean isDefault) {
 		this.user = user;
 		this.city = city;
 		this.district = district;
@@ -52,7 +63,8 @@ public class Address extends BaseEntity { // 배송지
 		this.isDefault = isDefault;
 	}
 
-	public static Address create(User user, String city, String district, String streetName, String streetNumber, String detail, Boolean isDefault) {
+	public static Address create(User user, String city, String district,
+								 String streetName, String streetNumber, String detail, Boolean isDefault) {
 		return Address.builder()
 				.user(user)
 				.city(city)

--- a/src/main/java/com/sparta/project/dto/address/AddressUpdateRequest.java
+++ b/src/main/java/com/sparta/project/dto/address/AddressUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.sparta.project.dto.address;
+
+
+public record AddressUpdateRequest(
+        String city,
+        String district,
+        String streetName,
+        String streetNumber,
+        String detail,
+        Boolean isDefault
+) {
+}

--- a/src/main/java/com/sparta/project/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/project/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호 정보가 일치하지 않습니다."),
 
     // Address
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 배송지 정보가 존재하지 않습니다."),
     EXCEED_MAXIMUM_ADDRESS(HttpStatus.CONFLICT, "등록할 수 있는 최대 배송지 수를 초과했습니다."),
 
     // Location

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -27,8 +27,7 @@ public class AddressService {
             throw new CodeBloomException(ErrorCode.EXCEED_MAXIMUM_ADDRESS);
         }
         if(request.isDefault() && alreadyExistDefault(user)) {
-            Address defaultAddress = addressRepository.findByUserAndIsDefault(user, true);
-            defaultAddress.updateDefault(false);
+            changeDefaultAddress(user);
         }
         addressRepository.save(Address.create(
                 user, request.city(), request.district(), request.streetName(),
@@ -41,6 +40,9 @@ public class AddressService {
         User user = userService.getUserOrException(userId);
         Address address = getAddressOrException(addressId);
         checkAddressOwner(user, address.getUser());
+        if(request.isDefault() && alreadyExistDefault(user)) {
+            changeDefaultAddress(user);
+        }
         address.update(request.city(), request.district(), request.streetName(),
                 request.streetNumber(), request.detail(), request.isDefault()
         );
@@ -54,6 +56,10 @@ public class AddressService {
         return addressRepository.existsByUserAndIsDefault(user, true);
     }
 
+    private void changeDefaultAddress(User user) {
+        Address defaultAddress = addressRepository.findByUserAndIsDefault(user, true);
+        defaultAddress.updateDefault(false);
+    }
 
     private void checkAddressOwner(User requestUser, User ownerUser) {
         if(requestUser != ownerUser) {

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -44,6 +44,7 @@ public class AddressService {
     public void updateAddress(long userId, String addressId, AddressUpdateRequest request) {
         User user = userService.getUserOrException(userId);
         Address address = getAddressOrException(addressId);
+        checkAddressOwner(user, address.getUser());
         address.update(request.city(), request.district(), request.streetName(),
                 request.streetNumber(), request.detail(), request.isDefault()
         );
@@ -57,6 +58,12 @@ public class AddressService {
         return addressRepository.existsByUserAndIsDefault(user, true);
     }
 
+
+    private void checkAddressOwner(User requestUser, User ownerUser) {
+        if(requestUser != ownerUser) {
+            throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
 
     private Address getAddressOrException(final String addressId) {
         return addressRepository.findById(addressId).orElseThrow(()->

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -3,7 +3,6 @@ package com.sparta.project.service;
 
 import com.sparta.project.domain.Address;
 import com.sparta.project.domain.User;
-import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.address.AddressCreateRequest;
 import com.sparta.project.dto.address.AddressUpdateRequest;
 import com.sparta.project.exception.CodeBloomException;
@@ -24,9 +23,6 @@ public class AddressService {
     @Transactional
     public void createAddress(final long userId, final AddressCreateRequest request) {
         User user = userService.getUserOrException(userId);
-        if(user.getRole() != Role.CUSTOMER) {
-            throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
-        }
         if(overMaxAddress(user)) {
             throw new CodeBloomException(ErrorCode.EXCEED_MAXIMUM_ADDRESS);
         }

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -5,6 +5,7 @@ import com.sparta.project.domain.Address;
 import com.sparta.project.domain.User;
 import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.address.AddressCreateRequest;
+import com.sparta.project.dto.address.AddressUpdateRequest;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.repository.AddressRepository;
@@ -39,12 +40,28 @@ public class AddressService {
         ));
     }
 
+    @Transactional
+    public void updateAddress(long userId, String addressId, AddressUpdateRequest request) {
+        User user = userService.getUserOrException(userId);
+        Address address = getAddressOrException(addressId);
+        address.update(request.city(), request.district(), request.streetName(),
+                request.streetNumber(), request.detail(), request.isDefault()
+        );
+    }
+
     private boolean overMaxAddress(final User user) {
         return addressRepository.countByUser(user) > 5;
     }
 
     private boolean alreadyExistDefault(final User user) {
         return addressRepository.existsByUserAndIsDefault(user, true);
+    }
+
+
+    private Address getAddressOrException(final String addressId) {
+        return addressRepository.findById(addressId).orElseThrow(()->
+                new CodeBloomException(ErrorCode.ADDRESS_NOT_FOUND)
+        );
     }
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #38 

배송지를 수정하는 API를 개발하였습니다.
- 요청 유저가 배송지의 주인이 아닌 경우 오류 반환
- 일치하는 배송지가 없는 경우 오류 반환




## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 배송지 정보가 없는 경우의 에러 코드 추가
- 배송지 엔티티에 업데이트 메서드 추가
- 배송지 업데이트 요청 객체 추가

기능 외 수정 사항
- 배송지 생성 API에서 권한이 CUSTOMER 인지 확인하는 내용을 permissionValidator 사용해 처리하도록 변경
- 배송지 생성 API의 반환 코드 201에서 200으로 변경 ( closed #29 )

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- 성공 (pgAdmin에서 변경 확인 완료)
![image](https://github.com/user-attachments/assets/5c8659bb-68d2-44e6-92ae-8d680c377f1b)

- 실패: 일치하는 배송지 정보가 없는 경우
![image](https://github.com/user-attachments/assets/0938fd74-8e0e-4a10-ad9f-2f089718651c)

- 실패: 로그인 한 유저가 배송지 주인이 아닌 경우
![image](https://github.com/user-attachments/assets/4a701ab4-b36f-48d8-9e73-1c1aa6ff909e)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선 방안 등 편하게 의견 주세요! 😃