### PR TITLE
[Feat] 회원가입 시의 유효성 검증 로직

### DIFF
--- a/src/main/java/com/sparta/project/domain/BaseEntity.java
+++ b/src/main/java/com/sparta/project/domain/BaseEntity.java
@@ -33,20 +33,15 @@ public abstract class BaseEntity {
     private LocalDateTime deletedAt;
 
     @CreatedBy
-    @Column(name="created_by", length=10)
+    @Column(name="created_by", length=2048)
     private String createdBy;
 
     @LastModifiedBy
-    @Column(name="updated_by", length=10)
+    @Column(name="updated_by", length=2048)
     private String updatedBy;
 
-    @Column(name="deleted_by", length=10)
+    @Column(name="deleted_by", length=2048)
     private String deletedBy;
-
-    /*
-    createdBy와 updatedBy는 스프링 시큐리티 부분이 구현되면 AuditorAware 구현체를 사용하는 방법으로 구현하겠습니다.
-    참고: https://javacpro.tistory.com/85
-     */
 
     public void deleteBase(String username) {
         this.isDeleted = true;

--- a/src/main/java/com/sparta/project/domain/User.java
+++ b/src/main/java/com/sparta/project/domain/User.java
@@ -21,13 +21,13 @@ public class User extends BaseEntity { // 유저
     @Column(name="user_id", nullable=false, updatable=false)
     private Long userId;
 
-    @Column(name="username", length=10, nullable=false) // 유저 고유 네임 (사용자 id)
+    @Column(name="username", length=2048, nullable=false) // 유저 고유 네임 (사용자 id)
     private String username;
 
-    @Column(name="password", length=255, nullable=false) // 비밀번호
+    @Column(name="password", length=2048, nullable=false) // 비밀번호
     private String password;
 
-    @Column(name="nickname", length=10) // 닉네임
+    @Column(name="nickname", length=2048) // 닉네임
     private String nickname;
 
     @Column(name="role", nullable=false) // 권한
@@ -50,7 +50,5 @@ public class User extends BaseEntity { // 유저
                 .role(role)
                 .build();
     }
-    // 만약 닉네임 초기값을 여기서 설정하고 싶다면, 파라미터에 nickname 지우고, this.nickname = "{defaultName}" 으로 설정하면 됩니다.
-    // 닉네임 초기값을 통일한다고 하면, @Builder.Default 활용해도 됩니다.
 
 }

--- a/src/main/java/com/sparta/project/dto/user/UserSignupRequest.java
+++ b/src/main/java/com/sparta/project/dto/user/UserSignupRequest.java
@@ -3,11 +3,25 @@ package com.sparta.project.dto.user;
 import com.sparta.project.domain.enums.Role;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record UserSignupRequest(
-        @NotBlank String username,
-        @NotBlank String password,
-        @NotBlank String nickname,
-        @NotNull Role role
+        @NotBlank
+        @Size(min = 4, max = 10, message = "유저 이름은 최소 4자 이상, 10자 이하여야 합니다.")
+        @Pattern(regexp = "^[a-z0-9]+$", message = "유저 이름은 영어 소문자와 숫자로 구성되어야 합니다.")
+        String username,
+
+        @NotBlank
+        @Size(min = 8, max = 15, message = "비밀번호은 최소 8자 이상, 15자 이하여야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+                message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함해야 합니다.")
+        String password,
+
+        @NotBlank
+        String nickname,
+
+        @NotNull
+        Role role
 ) {
 }

--- a/src/main/java/com/sparta/project/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/project/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 유저 정보가 존재하지 않습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "유저 이름이 이미 존재합니다."),
 
     // Address
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 배송지 정보가 존재하지 않습니다."),

--- a/src/main/java/com/sparta/project/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/sparta/project/exception/GlobalControllerAdvice.java
@@ -49,8 +49,8 @@ public class GlobalControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ExceptionResponse methodArgumentNotValidException(final MethodArgumentNotValidException e){
-        log.error(String.format(ERROR_LOG, e.getParameter(), e.getMessage()));
-        return new ExceptionResponse("전달된 데이터에 오류가 있습니다.");
+        //log.error(String.format(ERROR_LOG, e.getParameter(), e.getStatusCode()));
+        return new ExceptionResponse(e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
     }
 
 }

--- a/src/main/java/com/sparta/project/repository/UserRepository.java
+++ b/src/main/java/com/sparta/project/repository/UserRepository.java
@@ -5,5 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByUsername(String username);
     Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/sparta/project/service/UserService.java
+++ b/src/main/java/com/sparta/project/service/UserService.java
@@ -28,7 +28,9 @@ public class UserService {
 
     @Transactional
     public void createUser(final UserSignupRequest request) {
-        // TODO : 유효성 검사 필요
+        if(userRepository.existsByUsername(request.username())) {
+            throw new CodeBloomException(ErrorCode.DUPLICATE_USERNAME);
+        }
         userRepository.save(User.create(
                 request.username(), passwordEncoder.encode(request.password()),
                 request.nickname(), request.role())


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #33 

유효성 검증 로직을 추가했습니다.
- username은  최소 4자 이상, 10자 이하이며 알파벳 소문자(a-z), 숫자(0-9)로 구성
- password는  최소 8자 이상, 15자 이하이며 알파벳 대소문자(a-z, A-Z), 숫자(0-9), 특수문자
- 이미 존재하는 username인 경우 오류 반환
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BaseEntity의 ~By 크기 수정 (10->2048): 유저 생성 시 필드 크기가 작아서 저장이 안되는 문제가 있어 늘렸습니다.
- 유저 회원가입 요청 객체에 검증을 위한 패턴 추가
- 이미 유저가 존재하는 경우의 오류 코드 추가


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- username 체크
![image](https://github.com/user-attachments/assets/8b398d75-a1d2-44c5-9d52-0ee5a8384f17)

- password 체크
![image](https://github.com/user-attachments/assets/c639878f-8438-42bc-9be9-d006a49383f9)

- username이 이미 존재할 경우
![image](https://github.com/user-attachments/assets/c6872a04-7444-4420-a82f-6c14ce461f2e)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 중복 username의 있는 경우의 오류 메세지에 대해 다른 아이디어 있으시면 제안해주시면 감사하겠습니다!
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요~ 😃