### PR TITLE
[Feat] 배송지 상세 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -2,6 +2,7 @@ package com.sparta.project.controller;
 
 
 import com.sparta.project.domain.enums.Role;
+import com.sparta.project.dto.address.AddressAdminResponse;
 import com.sparta.project.dto.address.AddressCreateRequest;
 import com.sparta.project.dto.address.AddressResponse;
 import com.sparta.project.dto.address.AddressUpdateRequest;
@@ -44,6 +45,15 @@ public class AddressController {
         AddressResponse response = addressService.getAddressBy(Long.parseLong(authentication.getName()), address_id);
         return ApiResponse.success(response);
     }
+
+    @GetMapping("/{address_id}")
+    public ApiResponse<AddressAdminResponse> getAdminAddress(Authentication authentication,
+                                                             @PathVariable String address_id) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        AddressAdminResponse response = addressService.getAdminAddressBy(address_id);
+        return ApiResponse.success(response);
+    }
+
     @PatchMapping("/{address_id}")
     public ApiResponse<Void> updateAddress(Authentication authentication,
                                            @PathVariable String address_id,

--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -40,7 +40,7 @@ public class AddressController {
 
     @GetMapping("/my/{address_id}")
     public ApiResponse<AddressResponse> getAddress(Authentication authentication,
-                                                       @PathVariable String address_id) {
+                                                   @PathVariable String address_id) {
         permissionValidator.checkPermission(authentication, Role.CUSTOMER.name());
         AddressResponse response = addressService.getAddressBy(Long.parseLong(authentication.getName()), address_id);
         return ApiResponse.success(response);

--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -3,6 +3,7 @@ package com.sparta.project.controller;
 
 import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.address.AddressCreateRequest;
+import com.sparta.project.dto.address.AddressResponse;
 import com.sparta.project.dto.address.AddressUpdateRequest;
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.service.AddressService;
@@ -11,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,6 +37,13 @@ public class AddressController {
         return ApiResponse.success();
     }
 
+    @GetMapping("/my/{address_id}")
+    public ApiResponse<AddressResponse> getAddress(Authentication authentication,
+                                                       @PathVariable String address_id) {
+        permissionValidator.checkPermission(authentication, Role.CUSTOMER.name());
+        AddressResponse response = addressService.getAddressBy(Long.parseLong(authentication.getName()), address_id);
+        return ApiResponse.success(response);
+    }
     @PatchMapping("/{address_id}")
     public ApiResponse<Void> updateAddress(Authentication authentication,
                                            @PathVariable String address_id,
@@ -50,9 +59,8 @@ public class AddressController {
         return ApiResponse.success();
     }
 
-//
-//
-//    // 배송지 목록 조회(CUSTOMER, MANAGER, MASTER)
+
+// 배송지 목록 조회(CUSTOMER, MANAGER, MASTER)
 //    @GetMapping
 //    public ApiResponse<PageResponse<AddressResponse>> getAllAddresses(
 //            @RequestParam("page") int page,
@@ -60,13 +68,6 @@ public class AddressController {
 //            @RequestParam("sortBy") String sortBy) {
 //        Page<AddressResponse> addresses = addressService.getAllAddresses(page, size, sortBy);
 //        return ApiResponse.success(PageResponse.of(addresses));
-//    }
-//
-//    // 배송지 상세 조회(CUSTOMER)
-//    @GetMapping("/{address_id}")
-//    public ApiResponse<AddressResponse> getAddressById(@PathVariable String address_id) {
-//        AddressResponse address = addressService.getAddressById(address_id);
-//        return ApiResponse.success(address);
 //    }
 //
 //

--- a/src/main/java/com/sparta/project/dto/address/AddressAdminResponse.java
+++ b/src/main/java/com/sparta/project/dto/address/AddressAdminResponse.java
@@ -1,0 +1,42 @@
+package com.sparta.project.dto.address;
+
+import com.sparta.project.domain.Address;
+import java.time.LocalDateTime;
+
+public record AddressAdminResponse(
+        String AddressId,
+        String city,
+        String district,
+        String streetName,
+        String streetNumber,
+        String detail,
+        Boolean isDefault,
+        Long addressOwnerId,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy,
+        LocalDateTime deletedAt,
+        String deletedBy
+) {
+    public static AddressAdminResponse from(final Address address) {
+        return new AddressAdminResponse(
+                address.getAddressId(),
+                address.getCity(),
+                address.getDistrict(),
+                address.getStreetName(),
+                address.getStreetNumber(),
+                address.getDetail(),
+                address.getIsDefault(),
+                address.getUser().getUserId(),
+                address.getIsDeleted(),
+                address.getCreatedAt(),
+                address.getCreatedBy(),
+                address.getUpdatedAt(),
+                address.getUpdatedBy(),
+                address.getDeletedAt(),
+                address.getDeletedBy()
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/dto/address/AddressResponse.java
+++ b/src/main/java/com/sparta/project/dto/address/AddressResponse.java
@@ -1,0 +1,31 @@
+package com.sparta.project.dto.address;
+
+
+import com.sparta.project.domain.Address;
+import java.time.LocalDateTime;
+
+public record AddressResponse(
+        String AddressId,
+        String city,
+        String district,
+        String streetName,
+        String streetNumber,
+        String detail,
+        Boolean isDefault,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static AddressResponse from(final Address address) {
+        return new AddressResponse(
+                address.getAddressId(),
+                address.getCity(),
+                address.getDistrict(),
+                address.getStreetName(),
+                address.getStreetNumber(),
+                address.getDetail(),
+                address.getIsDefault(),
+                address.getCreatedAt(),
+                address.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -3,6 +3,7 @@ package com.sparta.project.service;
 
 import com.sparta.project.domain.Address;
 import com.sparta.project.domain.User;
+import com.sparta.project.dto.address.AddressAdminResponse;
 import com.sparta.project.dto.address.AddressCreateRequest;
 import com.sparta.project.dto.address.AddressResponse;
 import com.sparta.project.dto.address.AddressUpdateRequest;
@@ -45,6 +46,13 @@ public class AddressService {
         }
         return AddressResponse.from(address);
     }
+
+    @Transactional(readOnly = true)
+    public AddressAdminResponse getAdminAddressBy(String addressId) {
+        Address address = getAddressOrException(addressId);
+        return AddressAdminResponse.from(address);
+    }
+
     @Transactional
     public void updateAddress(long userId, String addressId, AddressUpdateRequest request) {
         User user = userService.getUserOrException(userId);

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -4,6 +4,7 @@ package com.sparta.project.service;
 import com.sparta.project.domain.Address;
 import com.sparta.project.domain.User;
 import com.sparta.project.dto.address.AddressCreateRequest;
+import com.sparta.project.dto.address.AddressResponse;
 import com.sparta.project.dto.address.AddressUpdateRequest;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
@@ -35,6 +36,15 @@ public class AddressService {
         ));
     }
 
+    @Transactional(readOnly = true)
+    public AddressResponse getAddressBy(long userId, String addressId) {
+        Address address = getAddressOrException(addressId);
+        checkAddressOwner(userId, address.getUser().getUserId());
+        if(address.getIsDeleted()!=null) {
+            throw new CodeBloomException(ErrorCode.ADDRESS_NOT_FOUND);
+        }
+        return AddressResponse.from(address);
+    }
     @Transactional
     public void updateAddress(long userId, String addressId, AddressUpdateRequest request) {
         User user = userService.getUserOrException(userId);


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #54 

배송지를 상세 조회하는 API를 개발했습니다. 일반 유저용, 관리자용 API가 나눠집니다.

[일반 유저]
- 삭제된 주소의 조회를 요청할 시 오류
- 요청한 유저가 배송지의 주인이 아닌 경우 오류

관리자는 삭제된 주소도 조회할 수 있으며 삭제 시간이나 담당 유저 정보 등도 포함해 조회할 수 있습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 유저용, 관리자용 응답 객체 각각 생성
- 하나의 API를 두개로 분리

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 일반 유저 성공시 (/addresses/my/id)
![image](https://github.com/user-attachments/assets/565ffe87-7a80-411d-89ea-133052e72841)

- 관리자 성공시 (/addresses/id)
![image](https://github.com/user-attachments/assets/2114ba18-5efe-49c9-835d-ea9b4e41384e)

    로그 정보도 포함해 조회할 수 있습니다.

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 두 응답을 하나의 API로 처리할까 고민하다가 그냥 권한 체크를 컨트롤러쪽에서 할 수 있도록 나눴습니다! 
- 개발하면서 다른 도메인에서도 상세 조회에서 관리자는 로그 정보 볼 수 있게 하면 좋을 것 같다는 생각이 들었는데 괜찮으실까요?