### PR TITLE
[Feat] 유저 정보 수정 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/UserController.java
+++ b/src/main/java/com/sparta/project/controller/UserController.java
@@ -1,13 +1,18 @@
 package com.sparta.project.controller;
 
 
+import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.user.UserLoginRequest;
 import com.sparta.project.dto.user.UserSignupRequest;
 import com.sparta.project.dto.common.ApiResponse;
+import com.sparta.project.dto.user.UserUpdateRequest;
 import com.sparta.project.service.UserService;
+import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/users")
 public class UserController {
 
+    private final PermissionValidator  permissionValidator;
     private final UserService userService;
 
     @PostMapping("/signup")
@@ -32,41 +38,19 @@ public class UserController {
         return ApiResponse.success(Map.of("token", token));
     }
 
+    // 유저 정보 수정 (ALL)
+    @PatchMapping("")
+    public ApiResponse<Void> updateUser(Authentication authentication,
+                                        @Valid @RequestBody UserUpdateRequest request) {
+        userService.updateUser(Long.parseLong(authentication.getName()), request);
+        return ApiResponse.success();
+    }
+
 }
 
 
-//package com.sparta.project.controller;
-//
-//import com.sparta.project.dto.user.CreateUserRequest;
-//import com.sparta.project.dto.user.LoginUserRequest;
-//import com.sparta.project.dto.user.UpdateUserRequest;
-//import com.sparta.project.dto.user.UserResponse;
-//import com.sparta.project.dto.common.ApiResponse;
-//import com.sparta.project.dto.common.PageResponse;
-//import com.sparta.project.service.UserService;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.web.bind.annotation.*;
-//
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/users")
-//public class UserController {
-//
-//    private final UserService userService;
-//
-//    // 회원가입(ALL)
-//    @PostMapping("/signup")
-//    public ApiResponse<UserResponse> signUp(@RequestBody CreateUserRequest createUserRequest) {
-//        UserResponse userResponse = userService.createUser(createUserRequest);
-//        return ApiResponse.success(userResponse);
-//    }
-//
-//    // 로그인(ALL)
-//    @PostMapping("/login")
-//    public ApiResponse<String> login(@RequestBody LoginUserRequest loginUserRequest) {
-//        String token = userService.loginUser(loginUserRequest);
-//        return ApiResponse.success(token);
-//    }
+
+
 //
 //    // 전체 유저 조회(MANAGER, MASTER)
 //    @GetMapping
@@ -86,15 +70,6 @@ public class UserController {
 //    public ApiResponse<UserResponse> getUserById(@PathVariable Long user_id) {
 //        UserResponse userInfo = userService.getUserById(user_id);
 //        return ApiResponse.success(userInfo);
-//    }
-//
-//    // 회원정보 수정(ALL)
-//    @PatchMapping("/{user_id}")
-//    public ApiResponse<UserResponse> updateUser(
-//            @PathVariable Long user_id,
-//            @RequestBody UpdateUserRequest updateUserRequest) {
-//        UserResponse updatedUser = userService.updateUser(user_id, updateUserRequest);
-//        return ApiResponse.success(updatedUser);
 //    }
 //
 //    // 회원 탈퇴(ALL)

--- a/src/main/java/com/sparta/project/domain/User.java
+++ b/src/main/java/com/sparta/project/domain/User.java
@@ -34,6 +34,12 @@ public class User extends BaseEntity { // 유저
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    public void update(String username, String password, String nickname) {
+        if(username!=null) this.username = username;
+        if(password!=null) this.password = password;
+        if(nickname!=null) this.nickname = nickname;
+    }
+
     @Builder
     private User(String username, String password, String nickname, Role role) {
         this.username = username;

--- a/src/main/java/com/sparta/project/dto/user/UserUpdateRequest.java
+++ b/src/main/java/com/sparta/project/dto/user/UserUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.sparta.project.dto.user;
+
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserUpdateRequest(
+        @Size(min = 4, max = 10, message = "유저 이름은 최소 4자 이상, 10자 이하여야 합니다.")
+        @Pattern(regexp = "^[a-z0-9]+$", message = "유저 이름은 영어 소문자와 숫자로 구성되어야 합니다.")
+        String username,
+
+        @Size(min = 8, max = 15, message = "비밀번호은 최소 8자 이상, 15자 이하여야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+                message = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함해야 합니다.")
+        String password,
+
+        String nickname
+) {
+}

--- a/src/main/java/com/sparta/project/service/UserService.java
+++ b/src/main/java/com/sparta/project/service/UserService.java
@@ -5,6 +5,7 @@ import com.sparta.project.config.jwt.JwtUtil;
 import com.sparta.project.domain.User;
 import com.sparta.project.dto.user.UserLoginRequest;
 import com.sparta.project.dto.user.UserSignupRequest;
+import com.sparta.project.dto.user.UserUpdateRequest;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.repository.UserRepository;
@@ -44,6 +45,16 @@ public class UserService {
             throw new CodeBloomException(ErrorCode.INVALID_PASSWORD);
         }
         return jwtUtil.generateToken(String.valueOf(user.getUserId()), user.getRole());
+    }
+
+    @Transactional
+    public void updateUser(long userId, final UserUpdateRequest request) {
+        User user = getUserOrException(userId);
+        user.update(
+                request.username(),
+                (request.password()!=null)?passwordEncoder.encode(request.password()):null,
+                request.nickname()
+        );
     }
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #48

유저 정보를 수정하는 API를 개발했습니다. 
모든 권한의 유저가 접근 가능하며, 현재 로그인 된 유저의 정보를 변경합니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 수정 요청 객체 생성
- User 엔티티 클래스에 업데이트 메서드 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공
![image](https://github.com/user-attachments/assets/bd262deb-4128-4e8a-8d29-a84b75e2c43d)

pgadmin으로 필드 값 변경 확인했습니다!

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- Role은 맘대로 수정하지 못하도록 수정 요청 객체에 포함시키지 않았습니다. 
만약 권한 변경 필요한 경우 따로 MASTER가 변경시킬 수 있는 API가 필요할 것 같네요!
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃