### PR TITLE
[Feat] 자신의 음식점 목록 조회, 모든 권한을 위한 음식점 목록 조회

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreController.java
+++ b/src/main/java/com/sparta/project/controller/StoreController.java
@@ -26,12 +26,11 @@ public class StoreController {
     // 자신의 음식점 조회(OWNER)
     @GetMapping("/my")
     public ApiResponse<PageResponse<StoreResponse>> getMyStores(
-            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
-            @RequestParam(value = "size", required = false, defaultValue = "5") int size,
-            @RequestParam(value = "sortBy", required = false, defaultValue = "storeId") String sortBy,
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "5") int size,
             Authentication authentication) {
         permissionValidator.checkPermission(authentication, Role.OWNER.name());
-        Page<StoreResponse> myStores = storeService.getMyStores(page, size, sortBy, Long.parseLong(authentication.getName()));
+        Page<StoreResponse> myStores = storeService.getMyStores(page, size, Long.parseLong(authentication.getName()));
         return ApiResponse.success(PageResponse.of(myStores));
     }
 
@@ -41,10 +40,9 @@ public class StoreController {
             @RequestParam(value = "name", required = false) String name,
             @RequestParam(value = "categoryId", required = false) String categoryId,
             @RequestParam(value = "menu", required = false) String menu,
-            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
-            @RequestParam(value = "size", required = false, defaultValue = "5") int size,
-            @RequestParam(value = "sortBy", required = false, defaultValue = "storeId") String sortBy) {
-        Page<StoreResponse> stores = storeService.getAllStores(name, categoryId, menu, page, size, sortBy);
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "5") int size) {
+        Page<StoreResponse> stores = storeService.getAllStores(name, categoryId, menu, page, size);
         return ApiResponse.success(PageResponse.of(stores));
     }
 

--- a/src/main/java/com/sparta/project/controller/StoreController.java
+++ b/src/main/java/com/sparta/project/controller/StoreController.java
@@ -1,6 +1,7 @@
 package com.sparta.project.controller;
 
 
+import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.dto.store.StoreResponse;
@@ -21,17 +22,19 @@ public class StoreController {
     private final StoreService storeService;
     private final PermissionValidator permissionValidator;
 
-    //
-//    // 자신의 음식점 조회(OWNER)
-//    @GetMapping("/my")
-//    public ApiResponse<PageResponse<StoreResponse>> getMyStores(
-//            @RequestParam("page") int page,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy) {
-//        Page<StoreResponse> myStores = storeService.getMyStores(page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(myStores));
-//    }
-//
+
+    // 자신의 음식점 조회(OWNER)
+    @GetMapping("/my")
+    public ApiResponse<PageResponse<StoreResponse>> getMyStores(
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(value = "size", required = false, defaultValue = "5") int size,
+            @RequestParam(value = "sortBy", required = false, defaultValue = "storeId") String sortBy,
+            Authentication authentication) {
+        permissionValidator.checkPermission(authentication, Role.OWNER.name());
+        Page<StoreResponse> myStores = storeService.getMyStores(page, size, sortBy, Long.parseLong(authentication.getName()));
+        return ApiResponse.success(PageResponse.of(myStores));
+    }
+
     // 음식점 목록 조회(ALL)
     @GetMapping
     public ApiResponse<PageResponse<StoreResponse>> getAllStores(
@@ -40,7 +43,7 @@ public class StoreController {
             @RequestParam(value = "menu", required = false) String menu,
             @RequestParam(value = "page", required = false, defaultValue = "1") int page,
             @RequestParam(value = "size", required = false, defaultValue = "5") int size,
-            @RequestParam(value = "sortBy", required = false, defaultValue = "id") String sortBy) {
+            @RequestParam(value = "sortBy", required = false, defaultValue = "storeId") String sortBy) {
         Page<StoreResponse> stores = storeService.getAllStores(name, categoryId, menu, page, size, sortBy);
         return ApiResponse.success(PageResponse.of(stores));
     }

--- a/src/main/java/com/sparta/project/controller/StoreController.java
+++ b/src/main/java/com/sparta/project/controller/StoreController.java
@@ -2,12 +2,14 @@ package com.sparta.project.controller;
 
 
 import com.sparta.project.dto.common.ApiResponse;
+import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.dto.store.StoreResponse;
 import com.sparta.project.dto.store.StoreUpdateRequest;
 import com.sparta.project.service.StoreService;
 import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,19 +32,19 @@ public class StoreController {
 //        return ApiResponse.success(PageResponse.of(myStores));
 //    }
 //
-//    // 음식점 목록 조회(ALL)
-//    @GetMapping
-//    public ApiResponse<PageResponse<StoreResponse>> getAllStores(
-//            @RequestParam("name") String name,
-//            @RequestParam("categoryId") String categoryId,
-//            @RequestParam("menu") String menu,
-//            @RequestParam("page") int page,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy) {
-//        Page<StoreResponse> stores = storeService.getAllStores(name, categoryId, menu, page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(stores));
-//    }
-//
+    // 음식점 목록 조회(ALL)
+    @GetMapping
+    public ApiResponse<PageResponse<StoreResponse>> getAllStores(
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "categoryId", required = false) String categoryId,
+            @RequestParam(value = "menu", required = false) String menu,
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(value = "size", required = false, defaultValue = "5") int size,
+            @RequestParam(value = "sortBy", required = false, defaultValue = "id") String sortBy) {
+        Page<StoreResponse> stores = storeService.getAllStores(name, categoryId, menu, page, size, sortBy);
+        return ApiResponse.success(PageResponse.of(stores));
+    }
+
     // 음식점 상세 조회(ALL)
     @GetMapping("/{store_id}")
     public ApiResponse<StoreResponse> getStoreById(@PathVariable("store_id") String store_id) {

--- a/src/main/java/com/sparta/project/repository/StoreQueryRepository.java
+++ b/src/main/java/com/sparta/project/repository/StoreQueryRepository.java
@@ -4,10 +4,12 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.sparta.project.domain.QStore;
+import com.sparta.project.domain.QMenu;
 import com.sparta.project.domain.Store;
 import com.sparta.project.domain.StoreCategory;
+import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -15,9 +17,12 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.sparta.project.domain.QStore.store;
+
 /**
  * QueryDSL 사용 리포지토리
  * */
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class StoreQueryRepository {
@@ -30,14 +35,16 @@ public class StoreQueryRepository {
                                       Pageable pageable) {
 
         BooleanBuilder booleanBuilder = toBooleanBuilder(storeCategory, name, menu);
-        List<Store> contents = queryFactory.selectFrom(QStore.store)
+        List<Store> contents = queryFactory.selectFrom(store)
+                .leftJoin(QMenu.menu).on(store.storeId.eq(QMenu.menu.store.storeId))
                 .where(booleanBuilder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        JPAQuery<Long> count = queryFactory.select(QStore.store.count())
-                .from(QStore.store)
+        JPAQuery<Long> count = queryFactory.select(store.count())
+                .from(store)
+                .leftJoin(QMenu.menu).on(store.storeId.eq(QMenu.menu.store.storeId))
                 .where(booleanBuilder);
 
         return PageableExecutionUtils.getPage(contents, pageable, count::fetchOne);
@@ -53,16 +60,18 @@ public class StoreQueryRepository {
     }
 
     private BooleanExpression eqStoreCategory(StoreCategory storeCategory) {
-        return storeCategory != null ? QStore.store.storeCategory.eq(storeCategory) : null;
+        return storeCategory != null ? store.storeCategory.eq(storeCategory) : null;
     }
 
     private BooleanExpression likeName(String name) {
         String condition = name == null ? "" :name;
-        return QStore.store.name.like("%" + condition + "%");
+        return store.name.like("%" + condition + "%");
     }
 
     private BooleanExpression likeMenu(String menu) {
-        String condition = menu == null ? "" :menu;
-        return QStore.store.name.like("%" + condition + "%");
+        if (StringUtils.isBlank(menu)) {
+            return null; // menu가 null이거나 빈 문자열일 경우 조건 무시
+        }
+        return QMenu.menu.name.like("%" + menu + "%");
     }
 }

--- a/src/main/java/com/sparta/project/repository/StoreQueryRepository.java
+++ b/src/main/java/com/sparta/project/repository/StoreQueryRepository.java
@@ -56,6 +56,10 @@ public class StoreQueryRepository {
         booleanBuilder.and(eqStoreCategory(storeCategory));
         booleanBuilder.and(likeName(name));
         booleanBuilder.and(likeMenu(menu));
+        booleanBuilder.and(isNotDeleted());
+        if (menu != null) {
+            booleanBuilder.and(isNotClosedMenu());
+        }
         return booleanBuilder;
     }
 
@@ -73,5 +77,13 @@ public class StoreQueryRepository {
             return null; // menu가 null이거나 빈 문자열일 경우 조건 무시
         }
         return QMenu.menu.name.like("%" + menu + "%");
+    }
+
+    private BooleanExpression isNotDeleted() {
+        return store.isDeleted.isFalse();
+    }
+
+    private BooleanExpression isNotClosedMenu() {
+        return QMenu.menu.isClosed.isFalse();
     }
 }

--- a/src/main/java/com/sparta/project/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/project/repository/StoreRepository.java
@@ -1,9 +1,13 @@
 package com.sparta.project.repository;
 
 import com.sparta.project.domain.Store;
+import com.sparta.project.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StoreRepository extends JpaRepository<Store, String> {
+    Page<Store> findAllByOwner(User owner, Pageable pageable);
 }

--- a/src/main/java/com/sparta/project/service/StoreService.java
+++ b/src/main/java/com/sparta/project/service/StoreService.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,14 +28,13 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final StoreQueryRepository storeQueryRepository;
 
-    public Page<StoreResponse> getMyStores(int page, int size, String sortBy, Long ownerId) {
-        Sort sort = Sort.by(Sort.Direction.ASC, sortBy);
-        Pageable pageable = PageRequest.of(page - 1, size, sort);
+    public Page<StoreResponse> getMyStores(int page, int size, Long ownerId) {
+        Pageable pageable = PageRequest.of(page - 1, size);
         Page<Store> storePage = storeRepository.findAllByOwner(userService.getUserOrException(ownerId), pageable);
         return storePage.map(StoreResponse::from);
     }
 
-    public Page<StoreResponse> getAllStores(String storeName, String cagetoryId, String menu, int page, int size, String sortBy) {
+    public Page<StoreResponse> getAllStores(String storeName, String cagetoryId, String menu, int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Store> storePage = storeQueryRepository.searchWithPage(
                 cagetoryId != null ? storeCategoryService.getStoreCategoryOrException(cagetoryId) : null,

--- a/src/main/java/com/sparta/project/service/StoreService.java
+++ b/src/main/java/com/sparta/project/service/StoreService.java
@@ -6,20 +6,35 @@ import com.sparta.project.dto.store.StoreResponse;
 import com.sparta.project.dto.store.StoreUpdateRequest;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
+import com.sparta.project.repository.StoreQueryRepository;
 import com.sparta.project.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class StoreService {
 
     private final UserService userService;
-    private final StoreLocationService storeLocationService;
+    private final LocationService locationService;
     private final StoreCategoryService storeCategoryService;
     private final StoreRepository storeRepository;
+    private final StoreQueryRepository storeQueryRepository;
+
+    public Page<StoreResponse> getAllStores(String storeName, String cagetoryId, String menu, int page, int size, String sortBy) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Store> storePage = storeQueryRepository.searchWithPage(
+                cagetoryId != null ? storeCategoryService.getStoreCategoryOrException(cagetoryId) : null,
+                storeName, menu, pageable);
+        return storePage.map(StoreResponse::from);
+    }
 
     public void createStore(final StoreCreateData data) {
         storeRepository.save(Store.create(
@@ -42,7 +57,7 @@ public class StoreService {
 
         store.update(request.storeName(),
                 request.description(),
-                request.locationId() != null ? storeLocationService.getStoreLocationOrException(request.locationId()) : null,
+                request.locationId() != null ? locationService.getLocationOrException(request.locationId()) : null,
                 request.categoryId() != null ? storeCategoryService.getStoreCategoryOrException(request.categoryId()) : null);
 
         return storeId;

--- a/src/main/java/com/sparta/project/service/StoreService.java
+++ b/src/main/java/com/sparta/project/service/StoreService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,13 @@ public class StoreService {
     private final StoreCategoryService storeCategoryService;
     private final StoreRepository storeRepository;
     private final StoreQueryRepository storeQueryRepository;
+
+    public Page<StoreResponse> getMyStores(int page, int size, String sortBy, Long ownerId) {
+        Sort sort = Sort.by(Sort.Direction.ASC, sortBy);
+        Pageable pageable = PageRequest.of(page - 1, size, sort);
+        Page<Store> storePage = storeRepository.findAllByOwner(userService.getUserOrException(ownerId), pageable);
+        return storePage.map(StoreResponse::from);
+    }
 
     public Page<StoreResponse> getAllStores(String storeName, String cagetoryId, String menu, int page, int size, String sortBy) {
         Pageable pageable = PageRequest.of(page - 1, size);

--- a/src/test/java/com/sparta/project/repository/StoreQueryRepositoryTest.java
+++ b/src/test/java/com/sparta/project/repository/StoreQueryRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.sparta.project.repository;
+
+import com.sparta.project.domain.Location;
+import com.sparta.project.domain.Store;
+import com.sparta.project.domain.StoreCategory;
+import com.sparta.project.domain.User;
+import com.sparta.project.domain.enums.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class StoreQueryRepositoryTest {
+
+    @Autowired
+    StoreQueryRepository storeQueryRepository;
+
+    @Autowired
+    StoreRepository storeRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    LocationRepository locationRepository;
+
+    @Autowired
+    StoreCategoryRepository storeCategoryRepository;
+
+    @BeforeEach
+    void setup() {
+        User owner = User.create("griotold", "1234", "nicknick", Role.OWNER);
+        userRepository.save(owner);
+
+        Location location = Location.create("서울", "서울 상세한 설명");
+        locationRepository.save(location);
+
+        StoreCategory storeCategory = StoreCategory.create("중식", "중식 전문점");
+        StoreCategory storeCategory2 = StoreCategory.create("양식", "양식 전문점");
+        storeCategoryRepository.saveAll(List.of(storeCategory, storeCategory2));
+
+        Store store = Store.create("착한 중식점", "가격이 착한...", "서울 행당...", owner, storeCategory, location);
+
+        storeRepository.save(store);
+
+//        Menu.create("짜장면", )
+    }
+
+//    @DisplayName("카테고리, 이름, 메뉴로 검색 테스트")
+//    @Test
+//    void searchAllPage() {
+//        // given
+//
+//        // when
+//
+//        // then
+//    }
+
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #36 
자신의 음식점 목록 조회는 page, size, sort만 있어서 JpaRepository의 쿼리 메서드를 사용했고요.
모든 권한을 위한 음식점 목록 조회는 categoryId 전체일치, menu, storeName이 부분일치여서 queryDsl로 구현했습니다.  

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
음식점 목록 조회 테스트
![음식점목록조회](https://github.com/user-attachments/assets/735a00ca-bd81-4c49-9bbf-03958676aa21)

자신의 가게 조회 테스트
![자신의가게](https://github.com/user-attachments/assets/77590cac-5cae-425e-89c5-08a707947812)

자신의 가게 조회 - 다른 사장님
![자신의가게_다른사장님](https://github.com/user-attachments/assets/d31d31d4-ec93-4872-9a5d-b4bbd06c0358)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->

`@RequestParam` 사용할 때 required=false 를  지정해야 안 받고 싶은 조건들은 안 받을 수 있더라고요.