### PR TITLE
[Feat] 음식점 생성 요청 반려 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreRequestController.java
+++ b/src/main/java/com/sparta/project/controller/StoreRequestController.java
@@ -33,7 +33,7 @@ public class StoreRequestController {
     }
 
     @PostMapping("/{request_id}")
-    public ApiResponse<Void> updateStoreRequest(Authentication authentication,
+    public ApiResponse<Void> approveStoreRequest(Authentication authentication,
                                                 @PathVariable String request_id) {
         permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
         storeRequestService.approveStoreRequest(request_id);

--- a/src/main/java/com/sparta/project/controller/StoreRequestController.java
+++ b/src/main/java/com/sparta/project/controller/StoreRequestController.java
@@ -6,14 +6,14 @@ import com.sparta.project.dto.storerequest.StoreCreateRequest;
 import com.sparta.project.service.StoreRequestService;
 import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -40,13 +40,15 @@ public class StoreRequestController {
         return ApiResponse.success();
     }
 
-//
-//    // 음식점 생성 요청 반려(MANAGER, MASTER)
-//    @DeleteMapping("/{request_id}")
-//    public ApiResponse<Void> deleteStoreRequest(@PathVariable String request_id) {
-//        storeRequestService.deleteStoreRequest(request_id);
-//        return ApiResponse.success();
-//    }
+    // 음식점 생성 요청 반려(MANAGER, MASTER)
+    @DeleteMapping("/{request_id}")
+    public ApiResponse<Void> rejectStoreRequest(Authentication authentication,
+                                                @PathVariable String request_id,
+                                                @NotBlank @RequestBody String rejectionReason) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        storeRequestService.rejectStoreRequest(Long.parseLong(authentication.getName()), request_id, rejectionReason);
+        return ApiResponse.success();
+    }
 
 //
 //    // 자신의 요청 목록 조회(OWNER)

--- a/src/main/java/com/sparta/project/domain/StoreRequest.java
+++ b/src/main/java/com/sparta/project/domain/StoreRequest.java
@@ -55,6 +55,10 @@ public class StoreRequest extends BaseEntity { // 음식점 허가 요청
 
 	public void updateStatus(StoreRequestStatus status) {
 		this.status = status;
+
+	public void reject(String rejectionReason) {
+		this.status = StoreRequestStatus.REJECT;
+		this.rejectionReason = rejectionReason;
 	}
 
 	@Builder

--- a/src/main/java/com/sparta/project/domain/StoreRequest.java
+++ b/src/main/java/com/sparta/project/domain/StoreRequest.java
@@ -32,6 +32,9 @@ public class StoreRequest extends BaseEntity { // 음식점 허가 요청
 	@Column(name="address", length=255) // 음식점 주소
 	private String address;
 
+	@Column(name="rejection_reason", length=2048)
+	private String rejectionReason;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name="owner_id", nullable=false)
 	private User owner;

--- a/src/main/java/com/sparta/project/domain/StoreRequest.java
+++ b/src/main/java/com/sparta/project/domain/StoreRequest.java
@@ -53,8 +53,9 @@ public class StoreRequest extends BaseEntity { // 음식점 허가 요청
 		this.status = StoreRequestStatus.WAITING;
 	}
 
-	public void updateStatus(StoreRequestStatus status) {
-		this.status = status;
+	public void approve() {
+		this.status = StoreRequestStatus.APPROVE;
+	}
 
 	public void reject(String rejectionReason) {
 		this.status = StoreRequestStatus.REJECT;

--- a/src/main/java/com/sparta/project/service/StoreRequestService.java
+++ b/src/main/java/com/sparta/project/service/StoreRequestService.java
@@ -41,7 +41,7 @@ public class StoreRequestService {
     public void approveStoreRequest(String storeRequestId) {
         StoreRequest storeRequest = getStoreRequestOrException(storeRequestId);
         checkAlreadyChanged(storeRequest.getStatus(), StoreRequestStatus.APPROVE);
-        storeRequest.updateStatus(StoreRequestStatus.APPROVE);
+        storeRequest.approve();
         storeService.createStore(StoreCreateData.from(storeRequest));
     }
 

--- a/src/main/java/com/sparta/project/service/StoreRequestService.java
+++ b/src/main/java/com/sparta/project/service/StoreRequestService.java
@@ -45,6 +45,14 @@ public class StoreRequestService {
         storeService.createStore(StoreCreateData.from(storeRequest));
     }
 
+    @Transactional
+    public void rejectStoreRequest(long userId, String storeRequestId, String rejectionReason) {
+        StoreRequest storeRequest = getStoreRequestOrException(storeRequestId);
+        checkAlreadyChanged(storeRequest.getStatus(), StoreRequestStatus.REJECT);
+        storeRequest.reject(rejectionReason);
+        storeRequest.deleteBase(String.valueOf(userId));
+    }
+
     private void checkAlreadyChanged(StoreRequestStatus before, StoreRequestStatus change) {
         if(before==change) {
             throw new CodeBloomException(ErrorCode.ALREADY_PROCESSED);


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #53 

가게 요청을 반려 (삭제) 하는 API를 개발했습니다. 반려 사유를 요청에 포함시켜야 합니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 가게 요청 엔티티에 반려 사유를 저장할 필드 추가
- 가게 요청 엔티티에 반려 메서드 추가


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공
![image](https://github.com/user-attachments/assets/93b9c62a-bd77-4d7e-baf4-ca72e197e88d)
pgadmin에서 반려 사유 저장, 삭제 로그 확인 완료되었습니다!

- 이미 반려한 요청인 경우
![image](https://github.com/user-attachments/assets/18929be2-055c-46ac-b72b-9b84dbfbf597)



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 전에 튜터님께서 살짝 말씀해주셨던 반려 사유를 추가했습니다! 
- 궁금하신 점, 개선할 점 등 의견 편하게 주세요! 😃