### PR TITLE
[Feat] 유저 삭제 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/UserController.java
+++ b/src/main/java/com/sparta/project/controller/UserController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,12 +47,18 @@ public class UserController {
         return ApiResponse.success();
     }
 
+    // 회원 탈퇴 (CUSTOMER, OWNER)
+    @DeleteMapping("/withdraw")
+    public ApiResponse<Void> delete(Authentication authentication) {
+        userService.withdraw(Long.parseLong(authentication.getName()));
+        permissionValidator.checkPermission(authentication, Role.CUSTOMER.name(), Role.OWNER.name());
+        return ApiResponse.success();
+    }
+
+
 }
 
 
-
-
-//
 //    // 전체 유저 조회(MANAGER, MASTER)
 //    @GetMapping
 //    public ApiResponse<PageResponse<UserResponse>> getAllUsers(
@@ -72,10 +79,4 @@ public class UserController {
 //        return ApiResponse.success(userInfo);
 //    }
 //
-//    // 회원 탈퇴(ALL)
-//    @DeleteMapping("/{user_id}")
-//    public ApiResponse<Void> deleteUser(@PathVariable Long user_id) {
-//        userService.deleteUser(user_id);
-//        return ApiResponse.success();
-//    }
 //}

--- a/src/main/java/com/sparta/project/controller/UserController.java
+++ b/src/main/java/com/sparta/project/controller/UserController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,6 +56,14 @@ public class UserController {
         return ApiResponse.success();
     }
 
+    // 회원 삭제 (MANAGER, MASTER)
+    @DeleteMapping("/{user_id}")
+    public ApiResponse<Void> deleteUser(Authentication authentication,
+                                        @PathVariable Long user_id) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        userService.deleteUser(Long.parseLong(authentication.getName()), user_id);
+        return ApiResponse.success();
+    }
 
 }
 

--- a/src/main/java/com/sparta/project/service/UserService.java
+++ b/src/main/java/com/sparta/project/service/UserService.java
@@ -62,4 +62,14 @@ public class UserService {
         User user = getUserOrException(userId);
         user.deleteBase(String.valueOf(userId));
     }
+
+    @Transactional
+    public void deleteUser(long adminId, long userId) {
+        User user = getUserOrException(userId);
+        if(user.getIsDeleted()) {
+            throw new CodeBloomException(ErrorCode.ALREADY_PROCESSED);
+        }
+        user.deleteBase(String.valueOf(adminId));
+    }
+
 }

--- a/src/main/java/com/sparta/project/service/UserService.java
+++ b/src/main/java/com/sparta/project/service/UserService.java
@@ -57,4 +57,9 @@ public class UserService {
         );
     }
 
+    @Transactional
+    public void withdraw(long userId) {
+        User user = getUserOrException(userId);
+        user.deleteBase(String.valueOf(userId));
+    }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #61 

유저를 삭제하는 API를 개발했습니다.
유저가 직접 탈퇴하는 방식, 관리자가 유저를 삭제하는 방식으로 분리했습니다.


## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
pgadmin에서 삭제 로그반영 확인되었습니다!
- 성공
![image](https://github.com/user-attachments/assets/082bbd4f-a735-4ea1-aaf9-802d9b4e1845)

- 이미 삭제한 유저의 id를 넘길 시 (관리자용)
![image](https://github.com/user-attachments/assets/ecd9782a-1855-4617-a03a-3ba091889434)



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 탈퇴라는 의미로 경로나 메서드명이나 withdraw로 사용했는데 혹시 다른 좋은 의견 있으시면 말씀해주세요!
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃