### PR TITLE
[Feat] 배송지 목록 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -7,9 +7,11 @@ import com.sparta.project.dto.address.AddressCreateRequest;
 import com.sparta.project.dto.address.AddressResponse;
 import com.sparta.project.dto.address.AddressUpdateRequest;
 import com.sparta.project.dto.common.ApiResponse;
+import com.sparta.project.dto.common.ListResponse;
 import com.sparta.project.service.AddressService;
 import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -38,6 +41,14 @@ public class AddressController {
         return ApiResponse.success();
     }
 
+    @GetMapping("/my")
+    public ApiResponse<ListResponse<AddressResponse>> getUserAddresses(Authentication authentication) {
+        permissionValidator.checkPermission(authentication, Role.CUSTOMER.name());
+        List<AddressResponse> responses = addressService.getUserAddresses(Long.parseLong(authentication.getName()));
+        return ApiResponse.success(ListResponse.of(responses));
+    }
+
+    // 로그인 된 유저의 자신의 배송지 조회 (CUSTOMER)
     @GetMapping("/my/{address_id}")
     public ApiResponse<AddressResponse> getAddress(Authentication authentication,
                                                    @PathVariable String address_id) {

--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -71,9 +71,10 @@ public class AddressController {
             @SortDefault(sort = "createdAt", direction = Direction.DESC)
             Pageable pageable,
             @RequestParam(value = "userId", required = false) Long userId,
+            @RequestParam(value = "city", required = false) String city,
             @RequestParam(value = "isDeleted", required = false) Boolean isDeleted) {
         permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
-        Page<AddressAdminResponse> result = addressService.getAllAddresses(pageable, userId, isDeleted);
+        Page<AddressAdminResponse> result = addressService.getAllAddresses(pageable, userId, city, isDeleted);
         return ApiResponse.success(PageResponse.of(result));
     }
 

--- a/src/main/java/com/sparta/project/controller/AddressController.java
+++ b/src/main/java/com/sparta/project/controller/AddressController.java
@@ -8,11 +8,17 @@ import com.sparta.project.dto.address.AddressResponse;
 import com.sparta.project.dto.address.AddressUpdateRequest;
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.common.ListResponse;
+import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.service.AddressService;
 import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,6 +63,20 @@ public class AddressController {
         return ApiResponse.success(response);
     }
 
+    // 전체 유저의 배송지 목록 조회 (MANAGER, MASTER)
+    @GetMapping("")
+    public ApiResponse<PageResponse<AddressAdminResponse>> getAllAddresses(
+            Authentication authentication,
+            @PageableDefault(size = 5)
+            @SortDefault(sort = "createdAt", direction = Direction.DESC)
+            Pageable pageable,
+            @RequestParam(value = "userId", required = false) Long userId,
+            @RequestParam(value = "isDeleted", required = false) Boolean isDeleted) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        Page<AddressAdminResponse> result = addressService.getAllAddresses(pageable, userId, isDeleted);
+        return ApiResponse.success(PageResponse.of(result));
+    }
+
     @GetMapping("/{address_id}")
     public ApiResponse<AddressAdminResponse> getAdminAddress(Authentication authentication,
                                                              @PathVariable String address_id) {
@@ -80,16 +100,4 @@ public class AddressController {
         return ApiResponse.success();
     }
 
-
-// 배송지 목록 조회(CUSTOMER, MANAGER, MASTER)
-//    @GetMapping
-//    public ApiResponse<PageResponse<AddressResponse>> getAllAddresses(
-//            @RequestParam("page") int page,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy) {
-//        Page<AddressResponse> addresses = addressService.getAllAddresses(page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(addresses));
-//    }
-//
-//
 }

--- a/src/main/java/com/sparta/project/dto/common/ListResponse.java
+++ b/src/main/java/com/sparta/project/dto/common/ListResponse.java
@@ -1,0 +1,15 @@
+package com.sparta.project.dto.common;
+
+import java.util.List;
+
+public record ListResponse<T> (
+        int size,
+        List<T> content
+) {
+    public static <T> ListResponse<T> of(List<T> content) {
+        return new ListResponse<>(
+                content.size(),
+                content
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/project/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
     // Util
     ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 방식입니다."),
 
     // UNAUTHORIZED & FORBIDDEN
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 존재하지 않습니다."),

--- a/src/main/java/com/sparta/project/repository/address/AddressCustomRepository.java
+++ b/src/main/java/com/sparta/project/repository/address/AddressCustomRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface AddressCustomRepository {
-    Page<Address> findAddressesWith(Pageable pageable, Long userId, Boolean isDeleted);
+    Page<Address> findAddressesWith(Pageable pageable, Long userId, String city, Boolean isDeleted);
 }

--- a/src/main/java/com/sparta/project/repository/address/AddressCustomRepository.java
+++ b/src/main/java/com/sparta/project/repository/address/AddressCustomRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.project.repository.address;
+
+
+import com.sparta.project.domain.Address;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AddressCustomRepository {
+    Page<Address> findAddressesWith(Pageable pageable, Long userId, Boolean isDeleted);
+}

--- a/src/main/java/com/sparta/project/repository/address/AddressCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/project/repository/address/AddressCustomRepositoryImpl.java
@@ -1,0 +1,84 @@
+package com.sparta.project.repository.address;
+
+
+import static com.sparta.project.domain.QAddress.address;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.project.domain.Address;
+import com.sparta.project.exception.CodeBloomException;
+import com.sparta.project.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AddressCustomRepositoryImpl implements AddressCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    // 일치하는 userId, 삭제 상태로 검색
+    @Override
+    public Page<Address> findAddressesWith(Pageable pageable,
+                                           Long userId,
+                                           Boolean isDeleted) {
+        BooleanBuilder booleanBuilder = toBooleanBuilder(userId, isDeleted);
+        List<Address> results = queryFactory.selectFrom(address)
+                .where(booleanBuilder)
+                .orderBy(getOrderSpecifiers(pageable)) // Sort 적용
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> count = queryFactory.select(address.count())
+                .from(address)
+                .where(booleanBuilder);
+
+        return PageableExecutionUtils.getPage(results, pageable, count::fetchOne);
+    }
+
+    private BooleanBuilder toBooleanBuilder(Long userName, Boolean isDeleted) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        booleanBuilder.and(eqUserId(userName));
+        booleanBuilder.and(eqIsDeleted(isDeleted));
+        return booleanBuilder;
+    }
+
+    private BooleanExpression eqUserId(Long userId) {
+        return userId != null ?  address.user.userId.eq(userId) : null;
+    }
+
+    private BooleanExpression eqIsDeleted(Boolean isDeleted) {
+        return isDeleted != null ? address.isDeleted.eq(isDeleted) : null;
+    }
+
+    // Pageable 의 Sort 객체를 기반으로 QueryDSL OrderSpecifier 배열을 생성하는 메서드
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = getSortPath(order.getProperty());
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    // 정렬 기준
+    private ComparableExpressionBase<?> getSortPath(String property) {
+        return switch (property) {
+            case "userId" -> address.user.userId;
+            case "createdAt" -> address.createdAt;
+            default -> throw new CodeBloomException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+        };
+    }
+}

--- a/src/main/java/com/sparta/project/repository/address/AddressCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/project/repository/address/AddressCustomRepositoryImpl.java
@@ -28,8 +28,9 @@ public class AddressCustomRepositoryImpl implements AddressCustomRepository {
     @Override
     public Page<Address> findAddressesWith(Pageable pageable,
                                            Long userId,
+                                           String city,
                                            Boolean isDeleted) {
-        BooleanBuilder booleanBuilder = toBooleanBuilder(userId, isDeleted);
+        BooleanBuilder booleanBuilder = toBooleanBuilder(userId, city, isDeleted);
         List<Address> results = queryFactory.selectFrom(address)
                 .where(booleanBuilder)
                 .orderBy(getOrderSpecifiers(pageable)) // Sort 적용
@@ -44,15 +45,20 @@ public class AddressCustomRepositoryImpl implements AddressCustomRepository {
         return PageableExecutionUtils.getPage(results, pageable, count::fetchOne);
     }
 
-    private BooleanBuilder toBooleanBuilder(Long userName, Boolean isDeleted) {
+    private BooleanBuilder toBooleanBuilder(Long userName, String city, Boolean isDeleted) {
         BooleanBuilder booleanBuilder = new BooleanBuilder();
         booleanBuilder.and(eqUserId(userName));
+        booleanBuilder.and(eqCity(city));
         booleanBuilder.and(eqIsDeleted(isDeleted));
         return booleanBuilder;
     }
 
     private BooleanExpression eqUserId(Long userId) {
         return userId != null ?  address.user.userId.eq(userId) : null;
+    }
+
+    private BooleanExpression eqCity(String city) {
+        return city != null ?  address.city.eq(city) : null;
     }
 
     private BooleanExpression eqIsDeleted(Boolean isDeleted) {

--- a/src/main/java/com/sparta/project/repository/address/AddressCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/project/repository/address/AddressCustomRepositoryImpl.java
@@ -48,7 +48,7 @@ public class AddressCustomRepositoryImpl implements AddressCustomRepository {
     private BooleanBuilder toBooleanBuilder(Long userName, String city, Boolean isDeleted) {
         BooleanBuilder booleanBuilder = new BooleanBuilder();
         booleanBuilder.and(eqUserId(userName));
-        booleanBuilder.and(eqCity(city));
+        booleanBuilder.and(likeCity(city));
         booleanBuilder.and(eqIsDeleted(isDeleted));
         return booleanBuilder;
     }
@@ -57,8 +57,8 @@ public class AddressCustomRepositoryImpl implements AddressCustomRepository {
         return userId != null ?  address.user.userId.eq(userId) : null;
     }
 
-    private BooleanExpression eqCity(String city) {
-        return city != null ?  address.city.eq(city) : null;
+    private BooleanExpression likeCity(String city) {
+        return address.city.like("%" + ((city!=null) ? city  : "") + "%");
     }
 
     private BooleanExpression eqIsDeleted(Boolean isDeleted) {

--- a/src/main/java/com/sparta/project/repository/address/AddressRepository.java
+++ b/src/main/java/com/sparta/project/repository/address/AddressRepository.java
@@ -1,14 +1,17 @@
-package com.sparta.project.repository;
+package com.sparta.project.repository.address;
 
 import com.sparta.project.domain.Address;
 import com.sparta.project.domain.User;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AddressRepository extends JpaRepository<Address, String> {
+public interface AddressRepository extends JpaRepository<Address, String>, AddressCustomRepository {
+    List<Address> findAllByUserAndIsDeleted(User user, Boolean isDeleted);
     Address findByUserAndIsDefault(User user, boolean isDefault);
     boolean existsByUserAndIsDefault(User user, boolean isDefault);
     int countByUser(User user);
-
 }

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -12,6 +12,8 @@ import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.repository.address.AddressRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +57,12 @@ public class AddressService {
             throw new CodeBloomException(ErrorCode.ADDRESS_NOT_FOUND);
         }
         return AddressResponse.from(address);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AddressAdminResponse> getAllAddresses(Pageable pageable, Long targetUserId, Boolean isDeleted) {
+        return addressRepository.findAddressesWith(pageable, targetUserId, isDeleted)
+                .map(AddressAdminResponse::from);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sparta/project/service/AddressService.java
+++ b/src/main/java/com/sparta/project/service/AddressService.java
@@ -60,8 +60,12 @@ public class AddressService {
     }
 
     @Transactional(readOnly = true)
-    public Page<AddressAdminResponse> getAllAddresses(Pageable pageable, Long targetUserId, Boolean isDeleted) {
-        return addressRepository.findAddressesWith(pageable, targetUserId, isDeleted)
+    public Page<AddressAdminResponse> getAllAddresses(
+            Pageable pageable,
+            Long targetUserId,
+            String city,
+            Boolean isDeleted) {
+        return addressRepository.findAddressesWith(pageable, targetUserId, city, isDeleted)
                 .map(AddressAdminResponse::from);
     }
 


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #64 

배송지의 목록을 조회하는 API를 개발했습니다. 두 API로 나눠집니다.
- CUSTOMER: 자신의 배송지 목록 List로 조회
- MANAGER, MASTER: 유저의 배송지 목록 조회
    - sort 파라미터에 `createAt,ASC`, `createAt,DESC` 값으로 생성 일자 정렬 가능 (기본: 생성일 내림차순)
    - page 파라미터로 조회할 페이지 선택
    - size 파라미터로 한 번에 조회할 크기 선택 
    - userId 파라미터로 일치하는 유저의 배송지 검색 가능
    - city 파라미터로 일치하는 도시 검색 가능
    - isDeleted 파라미터로 삭제 여부 필터링 가능
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- List용 공통 응답 객체를 생성했습니다.
- repository 밑에 address 패키지를 만들고 QueryDSL용 클래스들을 생성해 분리했습니다.
- 지원하지 않는 정렬 기준이 요청된 경우의 에러 코드를 추가했습니다.


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
여러 조건을 넣어가며 테스트를 할 수 있습니다.
- 성공: /addresses?userId=1&sort=createdAt,ASC&city=경기도
![image](https://github.com/user-attachments/assets/d8426e40-b1e8-4d2c-b742-46c75ebdf1ff)

    유저 id가 1이며 city가 경기도인 목록을 생성일 오름차순으로 조회

- 지원하지 않는 sort 값을 입력한 경우: /addresses?sort=any
![image](https://github.com/user-attachments/assets/1b589aa2-085a-49f9-a2a8-69765460f800)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- DSL을 해성님 코드를 참고하면서 해봤는데 Pageable에 sort를 넘겨줘도 QueryDSL 로 구현할 때 orderBy() 에 OrderSpecifier로 변환한 값을 안 넘겨주면 정렬이 제대로 이뤄지지 않더라구요. 따로 찾아서 추가해봤습니다!
- 궁금하신 점, 개선 방안 등 편하게 의견 주세요~ 😃