### PR TITLE
[Feat] 음식점 생성 요청 목록 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreRequestController.java
+++ b/src/main/java/com/sparta/project/controller/StoreRequestController.java
@@ -1,19 +1,29 @@
 package com.sparta.project.controller;
 
 import com.sparta.project.domain.enums.Role;
+import com.sparta.project.domain.enums.StoreRequestStatus;
 import com.sparta.project.dto.common.ApiResponse;
+import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.dto.storerequest.StoreCreateRequest;
+import com.sparta.project.dto.storerequest.StoreRequestAdminResponse;
 import com.sparta.project.service.StoreRequestService;
 import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -50,6 +60,24 @@ public class StoreRequestController {
         return ApiResponse.success();
     }
 
+    // 음식점 생성 요청 목록 조회(MANAGER, MASTER)
+    @GetMapping
+    public ApiResponse<PageResponse<StoreRequestAdminResponse>> getAllStoreRequests(
+            Authentication authentication,
+            @PageableDefault(size = 5)
+            @SortDefault(sort = "createdAt", direction = Direction.DESC)
+            Pageable pageable,
+            @RequestParam(value = "categoryId", required = false) String categoryId,
+            @RequestParam(value = "status", required = false) StoreRequestStatus status,
+            @RequestParam(value = "storeName", required = false) String storeName) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        Page<StoreRequestAdminResponse> result = storeRequestService.getAllStoreRequests(
+                pageable, categoryId, status, storeName
+        );
+        return ApiResponse.success(PageResponse.of(result));
+    }
+
+
 //
 //    // 자신의 요청 목록 조회(OWNER)
 //    @GetMapping("/my")
@@ -69,16 +97,6 @@ public class StoreRequestController {
 //            @RequestParam("sortBy") String sortBy) {
 //        Page<StoreRequestResponse> myRequest = storeRequestService.getStoreRequestById(request_id, page, size, sortBy);
 //        return ApiResponse.success(PageResponse.of(myRequest));
-//    }
-//
-//    // 음식점 생성 요청 목록 조회(MANAGER, MASTER)
-//    @GetMapping
-//    public ApiResponse<PageResponse<StoreRequestResponse>> getAllStoreRequests(
-//            @RequestParam("page") int page,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy) {
-//        Page<StoreRequestResponse> storeRequests = storeRequestService.getAllStoreRequests(page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(storeRequests));
 //    }
 //
 //    // 음식점 생성 요청 상세 조회(MANAGER, MASTER)

--- a/src/main/java/com/sparta/project/dto/storerequest/StoreRequestAdminResponse.java
+++ b/src/main/java/com/sparta/project/dto/storerequest/StoreRequestAdminResponse.java
@@ -1,0 +1,44 @@
+package com.sparta.project.dto.storerequest;
+
+
+import com.sparta.project.domain.StoreRequest;
+import com.sparta.project.domain.enums.StoreRequestStatus;
+import java.time.LocalDateTime;
+
+public record StoreRequestAdminResponse(
+        String storeRequestId,
+        StoreRequestStatus status,
+        String name,
+        String description,
+        String rejectionReason,
+        String storeCategoryId,
+        String locationId,
+        Long ownerId,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy,
+        LocalDateTime deletedAt,
+        String deletedBy
+) {
+    public static StoreRequestAdminResponse from(final StoreRequest storeRequest) {
+        return new StoreRequestAdminResponse(
+                storeRequest.getStoreRequestId(),
+                storeRequest.getStatus(),
+                storeRequest.getName(),
+                storeRequest.getDescription(),
+                storeRequest.getRejectionReason(),
+                storeRequest.getStoreCategory().getStoreCategoryId(),
+                storeRequest.getLocation().getLocationId(),
+                storeRequest.getOwner().getUserId(),
+                storeRequest.getIsDeleted(),
+                storeRequest.getCreatedAt(),
+                storeRequest.getCreatedBy(),
+                storeRequest.getUpdatedAt(),
+                storeRequest.getUpdatedBy(),
+                storeRequest.getDeletedAt(),
+                storeRequest.getDeletedBy()
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/repository/storerequest/StoreRequestCustomRepository.java
+++ b/src/main/java/com/sparta/project/repository/storerequest/StoreRequestCustomRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.project.repository.storerequest;
+
+import com.sparta.project.domain.StoreRequest;
+import com.sparta.project.domain.enums.StoreRequestStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface StoreRequestCustomRepository {
+    Page<StoreRequest> findStoreRequestsWith(
+            Pageable pageable, String categoryId, StoreRequestStatus status, String storeName);
+}

--- a/src/main/java/com/sparta/project/repository/storerequest/StoreRequestCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/project/repository/storerequest/StoreRequestCustomRepositoryImpl.java
@@ -1,0 +1,90 @@
+package com.sparta.project.repository.storerequest;
+
+import static com.sparta.project.domain.QStore.store;
+import static com.sparta.project.domain.QStoreRequest.storeRequest;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.project.domain.StoreRequest;
+import com.sparta.project.domain.enums.StoreRequestStatus;
+import com.sparta.project.exception.CodeBloomException;
+import com.sparta.project.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreRequestCustomRepositoryImpl implements StoreRequestCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<StoreRequest> findStoreRequestsWith(Pageable pageable,
+                                                    String categoryId,
+                                                    StoreRequestStatus status,
+                                                    String storeName) {
+        BooleanBuilder booleanBuilder = toBooleanBuilder(categoryId, status, storeName);
+        List<StoreRequest> results = queryFactory.selectFrom(storeRequest)
+                .where(booleanBuilder)
+                .orderBy(getOrderSpecifiers(pageable)) // Sort 적용
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> count = queryFactory.select(storeRequest.count())
+                .from(storeRequest)
+                .where(booleanBuilder);
+        return PageableExecutionUtils.getPage(results, pageable, count::fetchOne);
+    }
+
+
+    private BooleanBuilder toBooleanBuilder(String categoryId, StoreRequestStatus status, String storeName) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        booleanBuilder.and(eqCategoryId(categoryId));
+        booleanBuilder.and(eqStatus(status));
+        booleanBuilder.and(likeStoreName(storeName));
+        return booleanBuilder;
+    }
+
+    private BooleanExpression eqCategoryId(String categoryId) {
+        return categoryId != null ?  storeRequest.storeCategory.storeCategoryId.eq(categoryId) : null;
+    }
+
+    private BooleanExpression eqStatus(StoreRequestStatus status) {
+        return status != null ? storeRequest.status.eq(status) : null;
+    }
+
+    private BooleanExpression likeStoreName(String storeName) {
+        return store.name.like("%" + ((storeName!=null) ? storeName : "") + "%");
+    }
+
+    // Pageable 의 Sort 객체를 기반으로 QueryDSL OrderSpecifier 배열을 생성하는 메서드
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = getSortPath(order.getProperty());
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    // 정렬 기준
+    private ComparableExpressionBase<?> getSortPath(String property) {
+        return switch (property) {
+            case "userId" -> storeRequest.owner.userId;
+            case "createdAt" -> storeRequest.createdAt;
+            default -> throw new CodeBloomException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+        };
+    }
+}

--- a/src/main/java/com/sparta/project/repository/storerequest/StoreRequestCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/project/repository/storerequest/StoreRequestCustomRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.sparta.project.repository.storerequest;
 
-import static com.sparta.project.domain.QStore.store;
 import static com.sparta.project.domain.QStoreRequest.storeRequest;
 
 import com.querydsl.core.BooleanBuilder;
@@ -62,7 +61,7 @@ public class StoreRequestCustomRepositoryImpl implements StoreRequestCustomRepos
     }
 
     private BooleanExpression likeStoreName(String storeName) {
-        return store.name.like("%" + ((storeName!=null) ? storeName : "") + "%");
+        return storeRequest.name.like("%" + ((storeName!=null) ? storeName : "") + "%");
     }
 
     // Pageable 의 Sort 객체를 기반으로 QueryDSL OrderSpecifier 배열을 생성하는 메서드

--- a/src/main/java/com/sparta/project/repository/storerequest/StoreRequestRepository.java
+++ b/src/main/java/com/sparta/project/repository/storerequest/StoreRequestRepository.java
@@ -1,4 +1,4 @@
-package com.sparta.project.repository;
+package com.sparta.project.repository.storerequest;
 
 import com.sparta.project.domain.StoreRequest;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/sparta/project/repository/storerequest/StoreRequestRepository.java
+++ b/src/main/java/com/sparta/project/repository/storerequest/StoreRequestRepository.java
@@ -3,5 +3,5 @@ package com.sparta.project.repository.storerequest;
 import com.sparta.project.domain.StoreRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreRequestRepository extends JpaRepository<StoreRequest, String> {
+public interface StoreRequestRepository extends JpaRepository<StoreRequest, String>, StoreRequestCustomRepository {
 }

--- a/src/main/java/com/sparta/project/service/StoreRequestService.java
+++ b/src/main/java/com/sparta/project/service/StoreRequestService.java
@@ -7,10 +7,13 @@ import com.sparta.project.domain.enums.Role;
 import com.sparta.project.domain.enums.StoreRequestStatus;
 import com.sparta.project.dto.store.StoreCreateData;
 import com.sparta.project.dto.storerequest.StoreCreateRequest;
+import com.sparta.project.dto.storerequest.StoreRequestAdminResponse;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
-import com.sparta.project.repository.StoreRequestRepository;
+import com.sparta.project.repository.storerequest.StoreRequestRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +54,16 @@ public class StoreRequestService {
         checkAlreadyChanged(storeRequest.getStatus(), StoreRequestStatus.REJECT);
         storeRequest.reject(rejectionReason);
         storeRequest.deleteBase(String.valueOf(userId));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<StoreRequestAdminResponse> getAllStoreRequests(
+            Pageable pageable,
+            String categoryId,
+            StoreRequestStatus status,
+            String storeName) {
+        return storeRequestRepository.findStoreRequestsWith(pageable, categoryId, status, storeName)
+                .map(StoreRequestAdminResponse::from);
     }
 
     private void checkAlreadyChanged(StoreRequestStatus before, StoreRequestStatus change) {


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #25 

관리자의 음식점 생성 요청 목록을 조회하는 API를 개발했습니다.
- 권한 MANAGER, MASTER 아닌 경우 오류

[주요 파라미터]
- categoryId: 가게 카테고리로 필터링
- status: 승인 대기 중, 승인된 요청, 거절된 요청 필터링
- storeName: 해당 값을 포함하는 요청을 검색 가능
- sort: createAt.DESC, createAt.ASC 생성 일자 기준 오름차순, 내림차순 정렬 가능
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 음식점 생성 요청 관리자용 응답 객체 추가
- repository 하위에 storerequest 패키지 추가해서 repository 분리
- StoreRequest의 QueryDSL용 repository 클래스 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 권한이 없는 경우
![image](https://github.com/user-attachments/assets/32668b42-6fa6-4520-a892-0f3fb2ec9243)

- 지원하지 않는 정렬 방법 넘길 경우: /store-requests?sort=hi.DESC 
![image](https://github.com/user-attachments/assets/1c37a289-3197-4bba-aefa-573ee451d317)

- 성공: /store-requests?status=APPROVE&sort=createdAt,DESC?storeName=테
![image](https://github.com/user-attachments/assets/c78aedf8-e639-406d-9f14-27e8c66385d6)

    상태가 승인된 상태(APPROVE)이며 이름에 "테"가 들어가는 정보를 생성일자 내림차순 정렬

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃