### PR TITLE
[Feat] 가게 카테고리 상세 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/project/controller/StoreCategoryController.java
@@ -2,6 +2,7 @@ package com.sparta.project.controller;
 
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.storecategory.StoreCategoryCreateRequest;
+import com.sparta.project.dto.storecategory.StoreCategoryResponse;
 import com.sparta.project.dto.storecategory.StoreCategoryUpdateRequest;
 import com.sparta.project.service.StoreCategoryService;
 import com.sparta.project.util.PermissionValidator;
@@ -10,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,6 +53,16 @@ public class StoreCategoryController {
         return ApiResponse.success();
     }
 
+    // 음식점 카테고리 상세 조회(ALL)
+    @GetMapping("/{category_id}")
+    public ApiResponse<StoreCategoryResponse> getStoreCategoryById(Authentication authentication,
+                                                                   @PathVariable String category_id) {
+        StoreCategoryResponse response = storeCategoryService.getCategoryById(
+                Long.parseLong(authentication.getName()), category_id
+        );
+        return ApiResponse.success(response);
+    }
+
 //    음식점 카테고리 목록 조회(ALL)
 //    @GetMapping
 //    public ApiResponse<PageResponse<StoreCategoryResponse>> getAllStoreCategories(
@@ -60,13 +72,6 @@ public class StoreCategoryController {
 //            @RequestParam("sortBy") String sortBy) {
 //        Page<StoreCategoryResponse> storeCategories = storeCategoryService.getAllStoreCategories(name, page, size, sortBy);
 //        return ApiResponse.success(PageResponse.of(storeCategories));
-//    }
-//
-//    // 음식점 카테고리 상세 조회(ALL)
-//    @GetMapping("/{category_id}")
-//    public ApiResponse<StoreCategoryResponse> getStoreCategoryById(@PathVariable String category_id) {
-//        StoreCategoryResponse storeCategory = storeCategoryService.getStoreCategoryById(category_id);
-//        return ApiResponse.success(storeCategory);
 //    }
 
 }

--- a/src/main/java/com/sparta/project/dto/storecategory/StoreCategoryAdminResponse.java
+++ b/src/main/java/com/sparta/project/dto/storecategory/StoreCategoryAdminResponse.java
@@ -1,0 +1,33 @@
+package com.sparta.project.dto.storecategory;
+
+import com.sparta.project.domain.StoreCategory;
+import java.time.LocalDateTime;
+
+public record StoreCategoryAdminResponse(
+        String storeCategoryId,
+        String name,
+        String description,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy,
+        LocalDateTime deletedAt,
+        String deletedBy
+) implements StoreCategoryResponse {
+
+    public static StoreCategoryAdminResponse from(StoreCategory storeCategory) {
+        return new StoreCategoryAdminResponse(
+                storeCategory.getStoreCategoryId(),
+                storeCategory.getName(),
+                storeCategory.getDescription(),
+                storeCategory.getIsDeleted(),
+                storeCategory.getCreatedAt(),
+                storeCategory.getCreatedBy(),
+                storeCategory.getUpdatedAt(),
+                storeCategory.getUpdatedBy(),
+                storeCategory.getDeletedAt(),
+                storeCategory.getDeletedBy()
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/dto/storecategory/StoreCategoryResponse.java
+++ b/src/main/java/com/sparta/project/dto/storecategory/StoreCategoryResponse.java
@@ -1,0 +1,4 @@
+package com.sparta.project.dto.storecategory;
+
+public interface StoreCategoryResponse {
+}

--- a/src/main/java/com/sparta/project/dto/storecategory/StoreCategoryUserResponse.java
+++ b/src/main/java/com/sparta/project/dto/storecategory/StoreCategoryUserResponse.java
@@ -1,0 +1,23 @@
+package com.sparta.project.dto.storecategory;
+
+import com.sparta.project.domain.StoreCategory;
+import java.time.LocalDateTime;
+
+public record StoreCategoryUserResponse(
+        String storeCategoryId,
+        String name,
+        String description,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) implements StoreCategoryResponse {
+
+    public static StoreCategoryUserResponse from(StoreCategory storeCategory) {
+        return new StoreCategoryUserResponse(
+                storeCategory.getStoreCategoryId(),
+                storeCategory.getName(),
+                storeCategory.getDescription(),
+                storeCategory.getCreatedAt(),
+                storeCategory.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/project/service/StoreCategoryService.java
@@ -1,8 +1,13 @@
 package com.sparta.project.service;
 
 import com.sparta.project.domain.StoreCategory;
+import com.sparta.project.domain.User;
+import com.sparta.project.domain.enums.Role;
+import com.sparta.project.dto.storecategory.StoreCategoryAdminResponse;
 import com.sparta.project.dto.storecategory.StoreCategoryCreateRequest;
+import com.sparta.project.dto.storecategory.StoreCategoryResponse;
 import com.sparta.project.dto.storecategory.StoreCategoryUpdateRequest;
+import com.sparta.project.dto.storecategory.StoreCategoryUserResponse;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.repository.StoreCategoryRepository;
@@ -14,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StoreCategoryService {
 
+    private final UserService userService;
     private final StoreCategoryRepository storeCategoryRepository;
 
     public StoreCategory getStoreCategoryOrException(String categoryId) {
@@ -38,6 +44,22 @@ public class StoreCategoryService {
     public void deleteStoreCategory(String userId, String categoryId) {
         StoreCategory storeCategory = getStoreCategoryOrException(categoryId);
         storeCategory.deleteBase(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public StoreCategoryResponse getCategoryById(long userId, String categoryId) {
+        StoreCategory storeCategory = getStoreCategoryOrException(categoryId);
+        User user = userService.getUserOrException(userId);
+        if(!isAdmin(user.getRole()) && storeCategory.getIsDeleted()!=null) {
+            throw new CodeBloomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        return (isAdmin(user.getRole()))
+                ? StoreCategoryAdminResponse.from(storeCategory)
+                : StoreCategoryUserResponse.from(storeCategory);
+    }
+
+    private boolean isAdmin(Role role) {
+        return role == Role.MANAGER || role == Role.MASTER;
     }
 
     private void checkNameDuplication(String newName) {


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #75 

가게 카테고리 단 건의 조회를 할 수 있는 API를 개발했습니다.
요청은 모든 권한의 유저가 할 수 있지만, 관리자의 경우 더 상세한 정보가 반환됩니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 응답 객체 생성
   - 인터페이스 생성 후 권한별로 구현체를 나눴습니다.


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- 요청을 일반 유저가 한 경우
![image](https://github.com/user-attachments/assets/fb01d087-40c3-4696-9351-759d3c9c6049)

- 요청을 관리자(MANAGER, MASTER) 가 한 경우
![image](https://github.com/user-attachments/assets/c9c1a1e8-a7ac-46ff-9c17-85422a57ba6d)

- 삭제된 카테고리를 일반 유저가 조회하려고 하는 경우
![image](https://github.com/user-attachments/assets/a59292bb-95bf-4e6d-9100-1aa0fc4b322f)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 의견 편하게 주세요! 😃