### PR TITLE
[Feat] 전체 유저 목록 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/UserController.java
+++ b/src/main/java/com/sparta/project/controller/UserController.java
@@ -2,6 +2,8 @@ package com.sparta.project.controller;
 
 
 import com.sparta.project.domain.enums.Role;
+import com.sparta.project.dto.common.PageResponse;
+import com.sparta.project.dto.user.UserAdminResponse;
 import com.sparta.project.dto.user.UserLoginRequest;
 import com.sparta.project.dto.user.UserSignupRequest;
 import com.sparta.project.dto.common.ApiResponse;
@@ -11,13 +13,20 @@ import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -65,22 +74,24 @@ public class UserController {
         return ApiResponse.success();
     }
 
+    // 전체 유저 조회 (MANAGER, MASTER)
+    @GetMapping
+    public ApiResponse<PageResponse<UserAdminResponse>> getAllUsers(
+            Authentication authentication,
+            @PageableDefault(size = 5)
+            @SortDefault(sort = "createdAt", direction = Direction.DESC)
+            Pageable pageable,
+            @RequestParam(value = "username", required = false) String username,
+            @RequestParam(value = "role", required = false) Role role,
+            @RequestParam(value = "isDeleted", required = false) Boolean isDeleted) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        Page<UserAdminResponse> result = userService.getAllUsersBy(pageable, username, role, isDeleted);
+        return ApiResponse.success(PageResponse.of(result));
+    }
+
 }
 
 
-//    // 전체 유저 조회(MANAGER, MASTER)
-//    @GetMapping
-//    public ApiResponse<PageResponse<UserResponse>> getAllUsers(
-//            @RequestParam("username") String username,
-//            @RequestParam("role") String role,
-//            @RequestParam("page") int page,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy
-//    ) {
-//        Page<UserResponse> allUsers = userService.getAllUsers(username, role, page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(allUsers));
-//    }
-//
 //    // 유저 단건 조회(MANAGER, MASTER)
 //    @GetMapping("/{user_id}")
 //    public ApiResponse<UserResponse> getUserById(@PathVariable Long user_id) {

--- a/src/main/java/com/sparta/project/dto/user/UserAdminResponse.java
+++ b/src/main/java/com/sparta/project/dto/user/UserAdminResponse.java
@@ -1,6 +1,35 @@
 package com.sparta.project.dto.user;
 
-public record UserResponse(
-Lon
+import com.sparta.project.domain.User;
+import com.sparta.project.domain.enums.Role;
+import java.time.LocalDateTime;
+
+public record UserAdminResponse(
+        Long userId,
+        String username,
+        String nickname,
+        Role role,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy,
+        LocalDateTime deletedAt,
+        String deletedBy
 ) {
+    public static UserAdminResponse from(final User user) {
+        return new UserAdminResponse(
+                user.getUserId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getRole(),
+                user.getIsDeleted(),
+                user.getCreatedAt(),
+                user.getCreatedBy(),
+                user.getUpdatedAt(),
+                user.getUpdatedBy(),
+                user.getDeletedAt(),
+                user.getDeletedBy()
+        );
+    }
 }

--- a/src/main/java/com/sparta/project/dto/user/UserAdminResponse.java
+++ b/src/main/java/com/sparta/project/dto/user/UserAdminResponse.java
@@ -1,0 +1,6 @@
+package com.sparta.project.dto.user;
+
+public record UserResponse(
+Lon
+) {
+}

--- a/src/main/java/com/sparta/project/initializer/DataInitializer.java
+++ b/src/main/java/com/sparta/project/initializer/DataInitializer.java
@@ -1,6 +1,6 @@
 //package com.sparta.project.initializer;
 //
-//import com.sparta.project.repository.UserRepository;
+//import com.sparta.project.repository.user.UserRepository;
 //import org.springframework.boot.CommandLineRunner;
 //import org.springframework.stereotype.Component;
 //import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/com/sparta/project/repository/user/UserCustomRepository.java
+++ b/src/main/java/com/sparta/project/repository/user/UserCustomRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.project.repository.user;
+
+import com.sparta.project.domain.User;
+import com.sparta.project.domain.enums.Role;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserCustomRepository {
+    Page<User> findUserWith(Pageable pageable, String username, Role role, Boolean isDeleted);
+}

--- a/src/main/java/com/sparta/project/repository/user/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/project/repository/user/UserCustomRepositoryImpl.java
@@ -1,0 +1,85 @@
+package com.sparta.project.repository.user;
+
+import static com.sparta.project.domain.QUser.user;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.project.domain.User;
+import com.sparta.project.domain.enums.Role;
+import com.sparta.project.exception.CodeBloomException;
+import com.sparta.project.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<User> findUserWith(Pageable pageable, String username, Role role, Boolean isDeleted) {
+        BooleanBuilder booleanBuilder = toBooleanBuilder(username, role, isDeleted);
+        List<User> results = queryFactory.selectFrom(user)
+                .where(booleanBuilder)
+                .orderBy(getOrderSpecifiers(pageable)) // Sort 적용
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> count = queryFactory.select(user.count())
+                .from(user)
+                .where(booleanBuilder);
+        return PageableExecutionUtils.getPage(results, pageable, count::fetchOne);
+    }
+
+    private BooleanBuilder toBooleanBuilder(String username, Role role, Boolean isDeleted) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        booleanBuilder.and(likeUsername(username));
+        booleanBuilder.and(eqRole(role));
+        booleanBuilder.and(eqIsDeleted(isDeleted));
+        return booleanBuilder;
+    }
+
+    private BooleanExpression likeUsername(String username) {
+        return user.username.like("%" + ((username!=null) ? username  : "") + "%");
+    }
+
+    private BooleanExpression eqRole(Role role) {
+        return role != null ?  user.role.eq(role) : null;
+    }
+
+    private BooleanExpression eqIsDeleted(Boolean isDeleted) {
+        return isDeleted != null ? user.isDeleted.eq(isDeleted) : null;
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = getSortPath(order.getProperty());
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    // 정렬 기준
+    private ComparableExpressionBase<?> getSortPath(String property) {
+        return switch (property) {
+            case "username" -> user.username;
+            case "createdAt" -> user.createdAt;
+            default -> throw new CodeBloomException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+        };
+    }
+
+}

--- a/src/main/java/com/sparta/project/repository/user/UserRepository.java
+++ b/src/main/java/com/sparta/project/repository/user/UserRepository.java
@@ -1,10 +1,10 @@
-package com.sparta.project.repository;
+package com.sparta.project.repository.user;
 
 import com.sparta.project.domain.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
 
     boolean existsByUsername(String username);
     Optional<User> findByUsername(String username);

--- a/src/main/java/com/sparta/project/service/AIService.java
+++ b/src/main/java/com/sparta/project/service/AIService.java
@@ -8,11 +8,11 @@ import com.sparta.project.dto.ai.AIResponse;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.repository.AIRepository;
-import com.sparta.project.repository.UserRepository;
+
+import com.sparta.project.repository.user.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.*;
 import org.springframework.http.*;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;

--- a/src/main/java/com/sparta/project/service/ReviewService.java
+++ b/src/main/java/com/sparta/project/service/ReviewService.java
@@ -9,7 +9,7 @@ import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.repository.OrderRepository;
 import com.sparta.project.repository.ReviewRepository;
 import com.sparta.project.repository.StoreRepository;
-import com.sparta.project.repository.UserRepository;
+import com.sparta.project.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/sparta/project/service/UserService.java
+++ b/src/main/java/com/sparta/project/service/UserService.java
@@ -3,13 +3,17 @@ package com.sparta.project.service;
 
 import com.sparta.project.config.jwt.JwtUtil;
 import com.sparta.project.domain.User;
+import com.sparta.project.domain.enums.Role;
+import com.sparta.project.dto.user.UserAdminResponse;
 import com.sparta.project.dto.user.UserLoginRequest;
 import com.sparta.project.dto.user.UserSignupRequest;
 import com.sparta.project.dto.user.UserUpdateRequest;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
-import com.sparta.project.repository.UserRepository;
+import com.sparta.project.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +59,16 @@ public class UserService {
                 (request.password()!=null)?passwordEncoder.encode(request.password()):null,
                 request.nickname()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserAdminResponse> getAllUsersBy(
+            Pageable pageable,
+            String username,
+            Role role,
+            Boolean isDeleted ) {
+        return userRepository.findUserWith(pageable, username, role, isDeleted)
+                .map(UserAdminResponse::from);
     }
 
     @Transactional

--- a/src/test/java/com/sparta/project/repository/StoreQueryRepositoryTest.java
+++ b/src/test/java/com/sparta/project/repository/StoreQueryRepositoryTest.java
@@ -5,6 +5,7 @@ import com.sparta.project.domain.Store;
 import com.sparta.project.domain.StoreCategory;
 import com.sparta.project.domain.User;
 import com.sparta.project.domain.enums.Role;
+import com.sparta.project.repository.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/sparta/project/service/PaymentServiceTest.java
+++ b/src/test/java/com/sparta/project/service/PaymentServiceTest.java
@@ -10,7 +10,7 @@ import com.sparta.project.dto.payment.PaymentResponse;
 import com.sparta.project.dto.payment.PaymentRequest;
 import com.sparta.project.repository.OrderRepository;
 import com.sparta.project.repository.PaymentRepository;
-import com.sparta.project.repository.UserRepository;
+import com.sparta.project.repository.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/sparta/project/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/project/service/StoreServiceTest.java
@@ -10,7 +10,7 @@ import com.sparta.project.dto.store.StoreUpdateRequest;
 import com.sparta.project.repository.LocationRepository;
 import com.sparta.project.repository.StoreCategoryRepository;
 import com.sparta.project.repository.StoreRepository;
-import com.sparta.project.repository.UserRepository;
+import com.sparta.project.repository.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #74 

전체 유저 목록을 조회하는 API를 개발했습니다. 
MASTER, MANAGER 권한을 가진 유저만 조회 가능합니다.

[주요 파라미터]
- username: 부분 일치하는 유저 검색
- role: 권한 별 필터링
- isDeleted: 삭제 여부로 필터링
- sort: username, createdAt 에 대해 DESC, ASC 조건으로 정렬 가능

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 쿼리 DSL을 위한 유저 Repo 클래스를 추가했습니다.
- repository 하위에 user 패키지를 생성해 user도메인의 Repo 클래스를 분리했습니다.
- 관리자용 유저 응답 객체를 생성했습니다.

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 삭제된 유저만 조회: /users?isDeleted=true
![image](https://github.com/user-attachments/assets/acea021e-c575-4f9e-af28-0404afb9a8b4)

- 권한이 MANAGER인 유저만 조회: /users?role=MANAGER
![image](https://github.com/user-attachments/assets/513c864c-c5a8-438e-a430-ced0d5c9645f)

- 유저이름에 특정 문자열이 들어가는 유저만 조회: /users?username=love
![image](https://github.com/user-attachments/assets/e001b692-c4d6-482d-89ed-6ebbf57d3b0a)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃