### PR TITLE
[Feat] 자신이 요청한 음식점 생성 요청 목록 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreRequestController.java
+++ b/src/main/java/com/sparta/project/controller/StoreRequestController.java
@@ -6,6 +6,7 @@ import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.dto.storerequest.StoreCreateRequest;
 import com.sparta.project.dto.storerequest.StoreRequestAdminResponse;
+import com.sparta.project.dto.storerequest.StoreRequestUserResponse;
 import com.sparta.project.service.StoreRequestService;
 import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
@@ -60,6 +61,22 @@ public class StoreRequestController {
         return ApiResponse.success();
     }
 
+    // 자신의 요청 목록 조회(OWNER)
+    @GetMapping("/my")
+    public ApiResponse<PageResponse<StoreRequestUserResponse>> getMyStoreRequests(
+            Authentication authentication,
+            @PageableDefault(size = 5)
+            @SortDefault(sort = "createdAt", direction = Direction.DESC)
+            Pageable pageable,
+            @RequestParam(value = "status", required = false) StoreRequestStatus status,
+            @RequestParam(value = "storeName", required = false) String storeName ) {
+        permissionValidator.checkPermission(authentication, Role.OWNER.name());
+        Page<StoreRequestUserResponse> result = storeRequestService.getAllUserStoreRequests(
+                Long.parseLong(authentication.getName()), pageable, status, storeName
+        );
+        return ApiResponse.success(PageResponse.of(result));
+    }
+
     // 음식점 생성 요청 목록 조회(MANAGER, MASTER)
     @GetMapping
     public ApiResponse<PageResponse<StoreRequestAdminResponse>> getAllStoreRequests(
@@ -78,17 +95,6 @@ public class StoreRequestController {
     }
 
 
-//
-//    // 자신의 요청 목록 조회(OWNER)
-//    @GetMapping("/my")
-//    public ApiResponse<PageResponse<StoreRequestResponse>> getMyStoreRequests(
-//            @RequestParam("page") int page,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy) {
-//        Page<StoreRequestResponse> myRequests = storeRequestService.getMyStoreRequests(page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(myRequests));
-//    }
-//
 //    // 음식점 생성 요청 상세 조회(OWNER)
 //    @GetMapping("/my/{request_id}")
 //    public ApiResponse<PageResponse<StoreRequestResponse>> getStoreRequestById(

--- a/src/main/java/com/sparta/project/dto/storerequest/StoreRequestUserResponse.java
+++ b/src/main/java/com/sparta/project/dto/storerequest/StoreRequestUserResponse.java
@@ -1,0 +1,35 @@
+package com.sparta.project.dto.storerequest;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sparta.project.domain.StoreRequest;
+import com.sparta.project.domain.enums.StoreRequestStatus;
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record StoreRequestUserResponse(
+        String storeRequestId,
+        StoreRequestStatus status,
+        String name,
+        String description,
+        String rejectionReason,
+        String storeCategoryId,
+        String locationId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime rejectedAt
+) {
+    public static StoreRequestUserResponse from(StoreRequest storeRequest) {
+        return new StoreRequestUserResponse(
+                storeRequest.getStoreRequestId(),
+                storeRequest.getStatus(),
+                storeRequest.getName(),
+                storeRequest.getDescription(),
+                storeRequest.getRejectionReason(),
+                storeRequest.getStoreCategory().getStoreCategoryId(),
+                storeRequest.getLocation().getLocationId(),
+                storeRequest.getCreatedAt(),
+                storeRequest.getUpdatedAt(),
+                storeRequest.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/repository/storerequest/StoreRequestCustomRepository.java
+++ b/src/main/java/com/sparta/project/repository/storerequest/StoreRequestCustomRepository.java
@@ -7,5 +7,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface StoreRequestCustomRepository {
     Page<StoreRequest> findStoreRequestsWith(
-            Pageable pageable, String categoryId, StoreRequestStatus status, String storeName);
+            Pageable pageable, String categoryId, StoreRequestStatus status, String storeName
+    );
+    Page<StoreRequest> findUserStoreRequestsWith(
+            Pageable pageable, Long userId, StoreRequestStatus status, String storeName
+    );
 }

--- a/src/main/java/com/sparta/project/service/StoreRequestService.java
+++ b/src/main/java/com/sparta/project/service/StoreRequestService.java
@@ -8,6 +8,7 @@ import com.sparta.project.domain.enums.StoreRequestStatus;
 import com.sparta.project.dto.store.StoreCreateData;
 import com.sparta.project.dto.storerequest.StoreCreateRequest;
 import com.sparta.project.dto.storerequest.StoreRequestAdminResponse;
+import com.sparta.project.dto.storerequest.StoreRequestUserResponse;
 import com.sparta.project.exception.CodeBloomException;
 import com.sparta.project.exception.ErrorCode;
 import com.sparta.project.repository.storerequest.StoreRequestRepository;
@@ -54,6 +55,16 @@ public class StoreRequestService {
         checkAlreadyChanged(storeRequest.getStatus(), StoreRequestStatus.REJECT);
         storeRequest.reject(rejectionReason);
         storeRequest.deleteBase(String.valueOf(userId));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<StoreRequestUserResponse> getAllUserStoreRequests(
+            long userId,
+            Pageable pageable,
+            StoreRequestStatus status,
+            String storeName) {
+        return storeRequestRepository.findUserStoreRequestsWith(pageable, userId, status, storeName)
+                .map(StoreRequestUserResponse::from);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #80 

현재 로그인 된 유저가 요청한 음식점 생성 요청 목록을 조회하는 API를 개발했습니다.
권한이 OWNER인 유저만 접근 가능합니다.

[주요 파라미터] 
- status: 승인/승인대기/반려 상태별 필터링
- storeName: 부분 일치하는 이름으로 검색

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 사용자용 음식점 요청 응답 객체 추가
- 커스텀 레포지토리에 유저용 메서드 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 조회 성공
![image](https://github.com/user-attachments/assets/e18c2d42-334c-4286-a955-f077ddf3ea48)

- 승인된 요청만 조회: /store-requests/my?status=APPROVE
![image](https://github.com/user-attachments/assets/4d3f1be6-f60b-4cc5-8cf0-2d02bfd9decf)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요~ 😃
