### PR TITLE
[Feat] 음식점 카테고리 목록 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/project/controller/StoreCategoryController.java
@@ -1,6 +1,7 @@
 package com.sparta.project.controller;
 
 import com.sparta.project.dto.common.ApiResponse;
+import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.dto.storecategory.StoreCategoryCreateRequest;
 import com.sparta.project.dto.storecategory.StoreCategoryResponse;
 import com.sparta.project.dto.storecategory.StoreCategoryUpdateRequest;
@@ -9,6 +10,11 @@ import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -63,15 +70,19 @@ public class StoreCategoryController {
         return ApiResponse.success(response);
     }
 
-//    음식점 카테고리 목록 조회(ALL)
-//    @GetMapping
-//    public ApiResponse<PageResponse<StoreCategoryResponse>> getAllStoreCategories(
-//            @RequestParam("name") String name,
-//            @RequestParam("page") int page,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy) {
-//        Page<StoreCategoryResponse> storeCategories = storeCategoryService.getAllStoreCategories(name, page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(storeCategories));
-//    }
+    // 음식점 카테고리 목록 조회(ALL)
+    @GetMapping
+    public ApiResponse<PageResponse<StoreCategoryResponse>> getAllStoreCategories(
+            Authentication authentication,
+            @PageableDefault(size = 5)
+            @SortDefault(sort = "createdAt", direction = Direction.DESC)
+            Pageable pageable,
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "isDeleted", required = false) Boolean isDeleted) {
+        Page<StoreCategoryResponse> result = storeCategoryService.getAllCategoriesBy(
+                Long.parseLong(authentication.getName()), pageable, name, isDeleted
+        );
+        return ApiResponse.success(PageResponse.of(result));
+    }
 
 }

--- a/src/main/java/com/sparta/project/repository/storecategory/StoreCategoryCustomRepository.java
+++ b/src/main/java/com/sparta/project/repository/storecategory/StoreCategoryCustomRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.project.repository.storecategory;
+
+import com.sparta.project.domain.StoreCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface StoreCategoryCustomRepository {
+    Page<StoreCategory> findAllWith(Pageable pageable, String name, Boolean isDeleted);
+}

--- a/src/main/java/com/sparta/project/repository/storecategory/StoreCategoryCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/project/repository/storecategory/StoreCategoryCustomRepositoryImpl.java
@@ -1,0 +1,82 @@
+package com.sparta.project.repository.storecategory;
+
+import static com.sparta.project.domain.QStoreCategory.storeCategory;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.project.domain.StoreCategory;
+import com.sparta.project.exception.CodeBloomException;
+import com.sparta.project.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreCategoryCustomRepositoryImpl implements StoreCategoryCustomRepository{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<StoreCategory> findAllWith(Pageable pageable, String categoryName, Boolean isDeleted) {
+        BooleanBuilder booleanBuilder = toBooleanBuilder(categoryName, isDeleted);
+        List<StoreCategory> results = queryFactory.selectFrom(storeCategory)
+                .where(booleanBuilder)
+                .orderBy(getOrderSpecifiers(pageable)) // Sort 적용
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> count = queryFactory.select(storeCategory.count())
+                .from(storeCategory)
+                .where(booleanBuilder);
+
+        return PageableExecutionUtils.getPage(results, pageable, count::fetchOne);
+    }
+
+    private BooleanBuilder toBooleanBuilder(String categoryName, Boolean isDeleted) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        booleanBuilder.and(likeName(categoryName));
+        booleanBuilder.and(eqIsDeleted(isDeleted));
+        return booleanBuilder;
+    }
+
+    private BooleanExpression likeName(String name) {
+        return storeCategory.name.like("%" + ((name!=null) ? name  : "") + "%");
+    }
+
+    private BooleanExpression eqIsDeleted(Boolean isDeleted) {
+        return isDeleted != null
+                ? (isDeleted) ? storeCategory.isDeleted.isTrue() : storeCategory.isDeleted.isNull()
+                : null;
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = getSortPath(order.getProperty());
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    // 정렬 기준
+    private ComparableExpressionBase<?> getSortPath(String property) {
+        return switch (property) {
+            case "categoryName" -> storeCategory.name;
+            case "createdAt" -> storeCategory.createdAt;
+            default -> throw new CodeBloomException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+        };
+    }
+
+}

--- a/src/main/java/com/sparta/project/repository/storecategory/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/project/repository/storecategory/StoreCategoryRepository.java
@@ -1,4 +1,4 @@
-package com.sparta.project.repository;
+package com.sparta.project.repository.storecategory;
 
 import com.sparta.project.domain.StoreCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 
-public interface StoreCategoryRepository extends JpaRepository<StoreCategory, String> {
+public interface StoreCategoryRepository extends JpaRepository<StoreCategory, String>, StoreCategoryCustomRepository {
     boolean existsByName(String name);
 }

--- a/src/test/java/com/sparta/project/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/project/service/StoreServiceTest.java
@@ -8,7 +8,6 @@ import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.store.StoreResponse;
 import com.sparta.project.dto.store.StoreUpdateRequest;
 import com.sparta.project.repository.LocationRepository;
-import com.sparta.project.repository.StoreCategoryRepository;
 import com.sparta.project.repository.StoreRepository;
 import com.sparta.project.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #83 

음식점 카테고리 목록을 조회하는 API를 개발했습니다. 
- 일반 사용자는 삭제되지 않은 카테고리만 조회됩니다.
- 관리자 권한 사용자는 삭제된 카테고리도 포함해 조회할 수 있으며 더 상세한 정보가 포함됩니다.

[주요 파라미터]
- sort: categoryName, createAt 조건으로 오름차순/내림차순 정렬 가능
- name: 카테고리 이름이 부분 일치하는 카테고리 검색
- isDeleted: 관리자만 사용 가능, 삭제 여부로 필터링
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- repository 하위에 storecategory 패키지 생성
- 쿼리 DSL 구현 레포지토리 추가, storecategory로 기존 레포 포함해 위치 이동


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- 일반 사용자 조회
![image](https://github.com/user-attachments/assets/cbad0296-1d83-4bbf-a5fa-277452ae6a4a)

- 관리자 조회
![image](https://github.com/user-attachments/assets/3a99e675-ea90-4f26-839f-bf2a56c3c03f)

- 카테고리 이름으로 검색: /categories?name=식
![image](https://github.com/user-attachments/assets/5d3f54ae-88c8-48be-ab36-c98976b9a928)

- 삭제된 카테고리만 조회: /categories?isDeleted=true
![image](https://github.com/user-attachments/assets/0cff63c7-a96b-49d1-a791-a0224b22c36f)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선 방안 등 편하게 의견 주세요! 😃