### PR TITLE
[Feat] 유저 상세 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/UserController.java
+++ b/src/main/java/com/sparta/project/controller/UserController.java
@@ -4,7 +4,9 @@ package com.sparta.project.controller;
 import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.dto.user.UserAdminResponse;
+import com.sparta.project.dto.user.UserBasicResponse;
 import com.sparta.project.dto.user.UserLoginRequest;
+import com.sparta.project.dto.user.UserResponse;
 import com.sparta.project.dto.user.UserSignupRequest;
 import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.user.UserUpdateRequest;
@@ -34,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/users")
 public class UserController {
 
-    private final PermissionValidator  permissionValidator;
+    private final PermissionValidator permissionValidator;
     private final UserService userService;
 
     @PostMapping("/signup")
@@ -60,8 +62,8 @@ public class UserController {
     // 회원 탈퇴 (CUSTOMER, OWNER)
     @DeleteMapping("/withdraw")
     public ApiResponse<Void> delete(Authentication authentication) {
-        userService.withdraw(Long.parseLong(authentication.getName()));
         permissionValidator.checkPermission(authentication, Role.CUSTOMER.name(), Role.OWNER.name());
+        userService.withdraw(Long.parseLong(authentication.getName()));
         return ApiResponse.success();
     }
 
@@ -72,6 +74,22 @@ public class UserController {
         permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
         userService.deleteUser(Long.parseLong(authentication.getName()), user_id);
         return ApiResponse.success();
+    }
+
+    // 자신의 정보 조회 (ALL)
+    @GetMapping("/my")
+    public ApiResponse<UserResponse> getUser(Authentication authentication) {
+        UserResponse result = userService.getUserById(Long.parseLong(authentication.getName()), false);
+        return ApiResponse.success(result);
+    }
+
+    // 회원 정보 조회 (MANAGER, MASTER)
+    @GetMapping("/{user_id}")
+    public ApiResponse<UserResponse> getUserById(Authentication authentication,
+                                                      @PathVariable Long user_id) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        UserResponse result = userService.getUserById(user_id, true);
+        return ApiResponse.success(result);
     }
 
     // 전체 유저 조회 (MANAGER, MASTER)
@@ -91,12 +109,3 @@ public class UserController {
 
 }
 
-
-//    // 유저 단건 조회(MANAGER, MASTER)
-//    @GetMapping("/{user_id}")
-//    public ApiResponse<UserResponse> getUserById(@PathVariable Long user_id) {
-//        UserResponse userInfo = userService.getUserById(user_id);
-//        return ApiResponse.success(userInfo);
-//    }
-//
-//}

--- a/src/main/java/com/sparta/project/dto/user/UserAdminResponse.java
+++ b/src/main/java/com/sparta/project/dto/user/UserAdminResponse.java
@@ -16,7 +16,7 @@ public record UserAdminResponse(
         String updatedBy,
         LocalDateTime deletedAt,
         String deletedBy
-) {
+)  implements UserResponse {
     public static UserAdminResponse from(final User user) {
         return new UserAdminResponse(
                 user.getUserId(),

--- a/src/main/java/com/sparta/project/dto/user/UserBasicResponse.java
+++ b/src/main/java/com/sparta/project/dto/user/UserBasicResponse.java
@@ -1,0 +1,25 @@
+package com.sparta.project.dto.user;
+
+import com.sparta.project.domain.User;
+import com.sparta.project.domain.enums.Role;
+import java.time.LocalDateTime;
+
+public record UserBasicResponse(
+        Long userId,
+        String username,
+        String nickname,
+        Role role,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) implements UserResponse {
+    public static UserBasicResponse from(User user) {
+        return new UserBasicResponse(
+                user.getUserId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getRole(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/project/dto/user/UserResponse.java
+++ b/src/main/java/com/sparta/project/dto/user/UserResponse.java
@@ -1,0 +1,4 @@
+package com.sparta.project.dto.user;
+
+public interface UserResponse {
+}

--- a/src/main/java/com/sparta/project/service/UserService.java
+++ b/src/main/java/com/sparta/project/service/UserService.java
@@ -5,7 +5,9 @@ import com.sparta.project.config.jwt.JwtUtil;
 import com.sparta.project.domain.User;
 import com.sparta.project.domain.enums.Role;
 import com.sparta.project.dto.user.UserAdminResponse;
+import com.sparta.project.dto.user.UserBasicResponse;
 import com.sparta.project.dto.user.UserLoginRequest;
+import com.sparta.project.dto.user.UserResponse;
 import com.sparta.project.dto.user.UserSignupRequest;
 import com.sparta.project.dto.user.UserUpdateRequest;
 import com.sparta.project.exception.CodeBloomException;
@@ -59,6 +61,14 @@ public class UserService {
                 (request.password()!=null)?passwordEncoder.encode(request.password()):null,
                 request.nickname()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public UserResponse getUserById(long userId, boolean isAdmin) {
+        User user = getUserOrException(userId);
+        return (isAdmin)
+                ? UserAdminResponse.from(user)
+                : UserBasicResponse.from(user);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #82 

한 유저의 정보를 상세 조회하는 API를 개발했습니다. 
- /my: 현재 로그인한 유저 자신의 정보를 조회합니다.
- /{user_id}: 유저 아이디와 일치하는 유저의 정보를 조회합니다. 관리자만 접근 가능합니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 유저 응답 인터페이스 생성
- 유저 기본 응답 객체 생성

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- my
![image](https://github.com/user-attachments/assets/9368238e-bedc-40ec-9398-3bc634824184)

- 권한이 없는 경우
![image](https://github.com/user-attachments/assets/b6e2cef0-f7d8-465b-ae70-29b42923ce64)

- id와 일치하는 유저 정보 조회
![image](https://github.com/user-attachments/assets/206e16fb-63b8-4046-a2f2-cab1a6ee55cb)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선 방안 등 편하게 의견 주세요! 😃