### PR TITLE
[Feat] 음식점 생성 요청 정보를 수정하는 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreRequestController.java
+++ b/src/main/java/com/sparta/project/controller/StoreRequestController.java
@@ -6,11 +6,13 @@ import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.dto.storerequest.StoreCreateRequest;
 import com.sparta.project.dto.storerequest.StoreRequestAdminResponse;
+import com.sparta.project.dto.storerequest.StoreRequestUpdateRequest;
 import com.sparta.project.dto.storerequest.StoreRequestUserResponse;
 import com.sparta.project.service.StoreRequestService;
 import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +22,7 @@ import org.springframework.data.web.SortDefault;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,7 +42,18 @@ public class StoreRequestController {
     @PostMapping
     public ApiResponse<Void> createStoreRequest(Authentication authentication,
                                                 @Valid @RequestBody StoreCreateRequest request) {
+        permissionValidator.checkPermission(authentication, Role.OWNER.name());
         storeRequestService.createStoreRequest(Long.parseLong(authentication.getName()), request);
+        return ApiResponse.success();
+    }
+
+    // 음식점 생성 요청 수정 (OWNER)
+    @PatchMapping("/{request_id}")
+    public ApiResponse<Void> updateStoreRequest(Authentication authentication,
+                                                @PathVariable String request_id,
+                                                @NotNull @RequestBody StoreRequestUpdateRequest request) {
+        permissionValidator.checkPermission(authentication, Role.OWNER.name());
+        storeRequestService.updateStoreRequest(Long.parseLong(authentication.getName()), request_id, request);
         return ApiResponse.success();
     }
 

--- a/src/main/java/com/sparta/project/domain/StoreRequest.java
+++ b/src/main/java/com/sparta/project/domain/StoreRequest.java
@@ -62,6 +62,14 @@ public class StoreRequest extends BaseEntity { // 음식점 허가 요청
 		this.rejectionReason = rejectionReason;
 	}
 
+	public void updateInfo(String name, String description, String address, StoreCategory category, Location location) {
+		if (name!=null) this.name = name;
+		if (description!=null) this.description = description;
+		if (address!=null) this.address = address;
+		if (category!=null) this.storeCategory = category;
+		if (location!=null) this.location = location;
+	}
+
 	@Builder
 	private StoreRequest(String id, String name, String description, String address, User owner, StoreCategory category, Location location) {
 		this.storeRequestId = id;

--- a/src/main/java/com/sparta/project/dto/storerequest/StoreRequestUpdateRequest.java
+++ b/src/main/java/com/sparta/project/dto/storerequest/StoreRequestUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.sparta.project.dto.storerequest;
+
+
+public record StoreRequestUpdateRequest(
+        String name,
+        String description,
+        String address,
+        String categoryId,
+        String locationId
+) {
+}

--- a/src/main/java/com/sparta/project/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/project/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
 
     // Store-request
     STORE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 가게 요청 정보가 존재하지 않습니다."),
+    STORE_REQUEST_UNABLE_MODIFY(HttpStatus.BAD_REQUEST, "승인 대기 상태의 요청만 수정 가능합니다."),
 
     // Store-category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 카테고리 정보가 존재하지 않습니다."),


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #84 

가게 생성을 요청한 정보를 수정하는 API를 개발했습니다.
- 권한이 OWNER인 유저만 접근 가능합니다.
- 해당 음식점 생성 요청의 요청자와 로그인 유저가 일치하지 않으면 오류가 반환됩니다.
- 요청의 상태가 대기중인 요청만 변경 가능합니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- StoreRequest 엔티티에 기본 정보 수정 메서드 추가
- 수정할 정보를 담을 요청 객체 추가
- 수정할 수 없는 상태인 경우의 에러 코드 추가


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 수정하려는 가게 요청 정보의 상태가 WAITING이 아닌 경우
![image](https://github.com/user-attachments/assets/becbd3af-7d1c-4939-a44d-24fe0ffe790b)

- 성공
![image](https://github.com/user-attachments/assets/9ad978d1-26c8-4cec-8cfb-03a067435fb3)
    pgadmin에서 필드값 변경 확인했습니다!
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 에러 코드 관련해서 더 좋은 네이밍 생각나시면 의견 주시면 감사하겠습니다!
- 궁금하신 점, 개선 방안 등 편하게 의견 주세요! 😃