### PR TITLE
[Feat] 음식점 생성 요청 상세 조회 API

### DIFF
--- a/src/main/java/com/sparta/project/controller/StoreRequestController.java
+++ b/src/main/java/com/sparta/project/controller/StoreRequestController.java
@@ -6,8 +6,9 @@ import com.sparta.project.dto.common.ApiResponse;
 import com.sparta.project.dto.common.PageResponse;
 import com.sparta.project.dto.storerequest.StoreCreateRequest;
 import com.sparta.project.dto.storerequest.StoreRequestAdminResponse;
+import com.sparta.project.dto.storerequest.StoreRequestResponse;
 import com.sparta.project.dto.storerequest.StoreRequestUpdateRequest;
-import com.sparta.project.dto.storerequest.StoreRequestUserResponse;
+import com.sparta.project.dto.storerequest.StoreRequestOwnerResponse;
 import com.sparta.project.service.StoreRequestService;
 import com.sparta.project.util.PermissionValidator;
 import jakarta.validation.Valid;
@@ -75,9 +76,31 @@ public class StoreRequestController {
         return ApiResponse.success();
     }
 
+    // 자신의 음식점 생성 요청 상세 조회(OWNER)
+    @GetMapping("/my/{request_id}")
+    public ApiResponse<StoreRequestResponse> getOwnerStoreRequestById(Authentication authentication,
+                                                                      @PathVariable String request_id) {
+        permissionValidator.checkPermission(authentication, Role.OWNER.name());
+        StoreRequestResponse result = storeRequestService.getStoreRequestBy(
+                Long.parseLong(authentication.getName()), request_id, false
+        );
+        return ApiResponse.success(result);
+    }
+
+    // 음식점 생성 요청 상세 조회(MANAGER, MASTER)
+    @GetMapping("/{request_id}")
+    public ApiResponse<StoreRequestResponse> getStoreRequestById(Authentication authentication,
+                                                                 @PathVariable String request_id) {
+        permissionValidator.checkPermission(authentication, Role.MANAGER.name(), Role.MASTER.name());
+        StoreRequestResponse result = storeRequestService.getStoreRequestBy(
+                Long.parseLong(authentication.getName()), request_id, true
+        );
+        return ApiResponse.success(result);
+    }
+
     // 자신의 요청 목록 조회(OWNER)
     @GetMapping("/my")
-    public ApiResponse<PageResponse<StoreRequestUserResponse>> getMyStoreRequests(
+    public ApiResponse<PageResponse<StoreRequestOwnerResponse>> getOwnerStoreRequests(
             Authentication authentication,
             @PageableDefault(size = 5)
             @SortDefault(sort = "createdAt", direction = Direction.DESC)
@@ -85,7 +108,7 @@ public class StoreRequestController {
             @RequestParam(value = "status", required = false) StoreRequestStatus status,
             @RequestParam(value = "storeName", required = false) String storeName ) {
         permissionValidator.checkPermission(authentication, Role.OWNER.name());
-        Page<StoreRequestUserResponse> result = storeRequestService.getAllUserStoreRequests(
+        Page<StoreRequestOwnerResponse> result = storeRequestService.getAllUserStoreRequests(
                 Long.parseLong(authentication.getName()), pageable, status, storeName
         );
         return ApiResponse.success(PageResponse.of(result));
@@ -107,28 +130,5 @@ public class StoreRequestController {
         );
         return ApiResponse.success(PageResponse.of(result));
     }
-
-
-//    // 음식점 생성 요청 상세 조회(OWNER)
-//    @GetMapping("/my/{request_id}")
-//    public ApiResponse<PageResponse<StoreRequestResponse>> getStoreRequestById(
-//            @PathVariable String request_id,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy) {
-//        Page<StoreRequestResponse> myRequest = storeRequestService.getStoreRequestById(request_id, page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(myRequest));
-//    }
-//
-//    // 음식점 생성 요청 상세 조회(MANAGER, MASTER)
-//    @GetMapping("/{request_id}")
-//    public ApiResponse<PageResponse<StoreRequestResponse>> getStoreRequestById(
-//            @PathVariable String request_id,
-//            @RequestParam("size") int size,
-//            @RequestParam("sortBy") String sortBy) {
-//        Page<StoreRequestResponse> storeRequest = storeRequestService.getStoreRequestById(request_id, page, size, sortBy);
-//        return ApiResponse.success(PageResponse.of(storeRequest));
-//    }
-//
-//
 
 }

--- a/src/main/java/com/sparta/project/dto/storerequest/StoreRequestAdminResponse.java
+++ b/src/main/java/com/sparta/project/dto/storerequest/StoreRequestAdminResponse.java
@@ -10,10 +10,10 @@ public record StoreRequestAdminResponse(
         StoreRequestStatus status,
         String name,
         String description,
-        String rejectionReason,
         String storeCategoryId,
         String locationId,
         Long ownerId,
+        String rejectionReason,
         Boolean isDeleted,
         LocalDateTime createdAt,
         String createdBy,
@@ -21,17 +21,17 @@ public record StoreRequestAdminResponse(
         String updatedBy,
         LocalDateTime deletedAt,
         String deletedBy
-) {
+) implements StoreRequestResponse {
     public static StoreRequestAdminResponse from(final StoreRequest storeRequest) {
         return new StoreRequestAdminResponse(
                 storeRequest.getStoreRequestId(),
                 storeRequest.getStatus(),
                 storeRequest.getName(),
                 storeRequest.getDescription(),
-                storeRequest.getRejectionReason(),
                 storeRequest.getStoreCategory().getStoreCategoryId(),
                 storeRequest.getLocation().getLocationId(),
                 storeRequest.getOwner().getUserId(),
+                storeRequest.getRejectionReason(),
                 storeRequest.getIsDeleted(),
                 storeRequest.getCreatedAt(),
                 storeRequest.getCreatedBy(),

--- a/src/main/java/com/sparta/project/dto/storerequest/StoreRequestOwnerResponse.java
+++ b/src/main/java/com/sparta/project/dto/storerequest/StoreRequestOwnerResponse.java
@@ -6,27 +6,27 @@ import com.sparta.project.domain.enums.StoreRequestStatus;
 import java.time.LocalDateTime;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record StoreRequestUserResponse(
+public record StoreRequestOwnerResponse(
         String storeRequestId,
-        StoreRequestStatus status,
         String name,
         String description,
-        String rejectionReason,
         String storeCategoryId,
         String locationId,
+        StoreRequestStatus status,
+        String rejectionReason,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         LocalDateTime rejectedAt
-) {
-    public static StoreRequestUserResponse from(StoreRequest storeRequest) {
-        return new StoreRequestUserResponse(
+) implements StoreRequestResponse {
+    public static StoreRequestOwnerResponse from(StoreRequest storeRequest) {
+        return new StoreRequestOwnerResponse(
                 storeRequest.getStoreRequestId(),
-                storeRequest.getStatus(),
                 storeRequest.getName(),
                 storeRequest.getDescription(),
-                storeRequest.getRejectionReason(),
                 storeRequest.getStoreCategory().getStoreCategoryId(),
                 storeRequest.getLocation().getLocationId(),
+                storeRequest.getStatus(),
+                storeRequest.getRejectionReason(),
                 storeRequest.getCreatedAt(),
                 storeRequest.getUpdatedAt(),
                 storeRequest.getDeletedAt()

--- a/src/main/java/com/sparta/project/dto/storerequest/StoreRequestResponse.java
+++ b/src/main/java/com/sparta/project/dto/storerequest/StoreRequestResponse.java
@@ -1,0 +1,4 @@
+package com.sparta.project.dto.storerequest;
+
+public interface StoreRequestResponse {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #88 

음식점 생성 요청 단건을 상세 조회하는 API를 개발했습니다. OWNER용, 관리자용으로 나누어집니다.
OWNER인 경우 조회하려는 store-request 의 주인이 로그인된 유저가 아닌 경우 권한 오류가 발생합니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 공통 응답 인터페이스 생성
- 응답 객체 안의 필드 순서 수정 (연관 있는 값들 묶음)
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 자신의 음식점 생성 요청 상세 확인: /my/{id}
![image](https://github.com/user-attachments/assets/bfdb1d3f-2590-4f7f-a7e3-223c3d1f28f7)

- 권한 없는 경우
![image](https://github.com/user-attachments/assets/cf204f10-5299-4f93-9ba2-d2d40a142e88)


- 음식점 생성 요청 상세 조회 /{id}
![image](https://github.com/user-attachments/assets/88cd142a-b9ad-4a67-ac0e-39f339fd0ce6)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요!